### PR TITLE
Translate documentation into Portuguese, Spanish, and French

### DIFF
--- a/i18n/es/docusaurus-plugin-content-docs/current/Level - 0/fork-skatehive.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/Level - 0/fork-skatehive.md
@@ -1,0 +1,247 @@
+---
+title: Guía para Fork Skatehive
+sidebar_position: 1
+---
+
+# Cómo hacer un Fork de Skatehive 🛹
+
+Vamos a hacer este tutorial para cualquiera que quiera crear su propio portal impulsado por Skatehive, como <a href="https://skatehive.app" class="button-link" target="_blank">**Skatehive.app**</a>.
+
+Tendrás que instalar algunas cosas en tu máquina para preparar tu entorno de desarrollo.
+
+El código aún está un poco desordenado, pero te invito a ser parte de este viaje de aprendizaje con nosotros. Este documento siempre se actualizará en: https://docs.skatehive.app
+
+## Índice
+
+- Instalar Git y configurar la cuenta de Github
+- Configurar claves SSH de Github
+- Hacer Fork del Repositorio 
+- Clonar/Descargar el Repositorio
+- Descargar e Instalar NodeJs
+- Instalar pnpm 
+- Instalar Dependencias con `pnpm`
+- Cambiar variables .env
+- Ejecutar con `pnpm dev`
+- Hacer algunas modificaciones solo por diversión
+- Enviar tus cambios a github 
+- Ponerlo en línea, desplegar tu versión con vercel 
+
+
+## Instalar Git y configurar la cuenta de Github
+
+Descarga e instala Git en tu máquina local. Eso te permitirá ejecutar comandos git en tu terminal, como `git clone` y otros comandos mágicos 
+
+
+[Descargar Git](https://git-scm.com/downloads)
+[Aprender más sobre git y su instalación](https://www.youtube.com/results?search_query=what+is+git+how+to+install)
+
+## Crear una cuenta de Github
+
+Solo regístrate 
+
+## Configurar claves SSH de Github 
+
+Para hacer el proceso más fluido, vamos a configurar una conexión SSH generando claves SSH. 
+
+
+1. Abre tu terminal 
+
+2. Escribe el siguiente comando
+> usa el mismo correo electrónico que usaste para crear la cuenta de github
+
+```
+ssh-keygen -t ed25519 -C "your_email@example.com"
+``` 
+> Esto crea una nueva clave SSH, usando el correo electrónico proporcionado como etiqueta.
+
+3. Inicia el agente ssh en segundo plano
+
+```
+eval "$(ssh-agent -s)"
+```
+
+4. Copia el contenido del archivo id_ed25519.pub en tu portapapeles
+
+- Para usuarios de Mac: 
+`pbcopy < ~/.ssh/id_ed25519.pub`
+
+- Para usuarios de Windows: 
+`clip < ~/.ssh/id_ed25519.pub`
+
+
+
+y dale un título y pega el contenido en Key
+![Alt ​​text](../../src/assets/Tuto-Dev/1.png)
+
+
+
+> [Tutorial completo de SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
+
+## Hacer Fork del Repositorio
+
+ **[Click Fork Button](https://github.com/SkateHive/nextskateapp)** 
+
+![Alt ​​text](../../src/assets/Tuto-Dev/2.png)
+
+Esto creará tu propia versión del repositorio en tu cuenta: 
+
+![Alt ​​text](../../src/assets/Tuto-Dev/3.png)
+
+Ok, ahora vas a clonar el repositorio de archivos en tu máquina, que básicamente es descargar la aplicación: 
+
+```
+git clone git@github.com:<your-username>/<your-fork>.git
+```
+
+![Alt ​​text](../../src/assets/Tuto-Dev/4.png)
+
+
+Ahora navega al repositorio clonado por: 
+
+```
+cd <your-fork>
+```
+
+En este caso, 
+
+```
+cd nextskateapp
+``` 
+
+Para el siguiente paso necesitaremos instalar algunos programas más en tu máquina para completar tu entorno y finalmente instalar y ejecutar la aplicación. 
+
+
+## [Descargar e instalar Node.Js](https://nodejs.org/en)
+
+> Nada especial aquí, solo instala y asegúrate de dejar marcada la opción `add to path`.
+
+## [Instalar pnpm Aquí](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) o 
+
+```
+npm install -g pnpm
+```
+
+> [Más formas de instalar Yarn](https://www.youtube.com/results?search_query=install+yarn)
+
+
+Si tienes Nodejs, npm, yarn y weed/coffee ahora puedes instalar y ejecutarlo en tu máquina local. 
+
+## Volviendo al Terminal... 
+
+En la carpeta del repositorio
+
+```
+pnpm i
+```
+> Nota: Este comando instalará automáticamente todos los paquetes y dependencias de JavaScript necesarios para tu proyecto, según lo especificado en el archivo package.json. Yarn descargará y configurará todo lo necesario para ejecutar tu portal Skatehive.
+Este paso asegura que tengas todas las bibliotecas y herramientas necesarias en tu entorno de desarrollo para construir y ejecutar la aplicación.
+
+
+![Alt ​​text](../../src/assets/Tuto-Dev/5.png)
+Espera un poco, toma un "café"...
+
+Deberías ver esto cuando termine: 
+![Alt ​​text](../../src/assets/Tuto-Dev/6.png)
+
+> Si obtienes un error en cualquier paso, puedes lanzarlo en chat-gpt o preguntarnos en [skatehive discord](https://discord.gg/skatehive) y ver cuál te ayuda más rápido 
+
+
+## Renombrar .env.example a .env 
+
+Renombra .env.example y elige la comunidad hive de la que deseas obtener/subir contenido. Por ejemplo, si usas hive-173115 obtendrás skatehive, si usas hive-141964 en el campo de la comunidad obtendrás surfhive 
+
+## .env.example
+NEXT_PUBLIC_WEBSITE_URL=http://localhost:3000/
+NEXT_PUBLIC_HIVE_COMMUNITY_TAG=xxxxxxxxxxx
+NEXT_PUBLIC_PINATA_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NEXT_PUBLIC_PINATA_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NEXT_PUBLIC_PINATA_GATEWAY_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NEXT_PUBLIC_CRYPTO_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NEXT_PUBLIC_OPENAI_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NEXT_PUBLIC_ETHERSCAN_API=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+Ahora ejecuta la aplicación que acabas de instalar: 
+
+```
+pnpm dev
+```
+![Alt ​​text](../../src/assets/Tuto-Dev/7.png)
+
+
+Ahora abre https://localhost:3000 <a href="https://skatehive.app" class="button-link" target="_blank"></a> y verás la misma aplicación que <a href="https://skatehive.app" class="button-link" target="_blank">**Website Skatehive**</a>.
+
+![Alt ​​text](../../src/assets/Tuto-Dev/8.png)
+
+Eso significa que estás ejecutando la aplicación usando tu propia computadora como servidor a través del puerto 3000 
+
+Ahora puedes intentar editar tu código en un editor de código, recomiendo <a href="https://code.visualstudio.com/" class="button-link" target="_blank">**Website VSCode**</a>, pero mi Maestro Jedi recomienda <a href="https://www.jetbrains.com/" class="button-link" target="_blank">**Website JetBrains**</a>.
+
+
+Normalmente uso el comando `code .` en la carpeta del terminal para abrir fácilmente la carpeta en la que estoy trabajando en VScode
+
+Haz un cambio tonto, como cambiar el pie de página. 
+
+![Alt ​​text](../../src/assets/Tuto-Dev/9.png)
+
+
+Este proyecto está construido con TypeScript e incorpora Chakra UI para el frontend. Para tareas relacionadas con Hive, confiamos en el <a href="https://play.hive-keychain.com/" class="button-link" target="_blank">**Website Keychain SDK**</a> y las bibliotecas dive. Además, para facilitar las interacciones con Ethereum, Bitcoin y varias otras blockchains, aprovechamos las capacidades de <a href="https://github.com/BitHighlander/pioneer-react#readme" class="button-link" target="_blank">**WebSite Pioneer-React**</a>.
+
+
+
+**Cambios de Etapa:**
+
+Antes de enviar a github es bueno: 
+
+```
+pnpm build:turbo 
+```
+
+y probar su compilación localmente!
+
+```
+git add .
+````
+> para preparar tus cambios para el commit.
+
+**Commit Changes:**
+
+```
+git commit -m "Changed header color".
+```
+> Commit con un mensaje 
+
+**Push to GitHub:**
+```
+git push origin main
+```
+> Enviar tus cambios 
+
+Ahora puedes ir a tu cuenta de github y verificar si se actualizó 
+
+## Poner tu sitio web en línea 
+
+## Ir a vercel.com 
+
+1. Crea una cuenta con tu cuenta de github 
+![Alt ​​text](../../src/assets/Tuto-Dev/10.png)
+
+2. Instala la extensión de Github que ofrece 
+3. Selecciona el repositorio 
+![Alt ​​text](../../src/assets/Tuto-Dev/11.png)
+
+4. Haz clic en Deploy
+
+Deberías ver algo como esto: 
+
+![Alt ​​text](../../src/assets/Tuto-Dev/12.png)
+ 
+
+Ahora puedes navegar a: 
+
+https://your-repo.vercel.app 
+
+y ver tu propia comunidad hive. 
+
+¡Felicidades! Eso es genial, ¡pusiste un sitio web sin permisos en línea! Ve a mostrarle a tu mamá, dile que la extraño. 
+
+--- 

--- a/i18n/es/docusaurus-plugin-content-docs/current/Level - 1/Discord-Share-Screen.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/Level - 1/Discord-Share-Screen.md
@@ -1,0 +1,73 @@
+# Cómo Compartir Tu Pantalla en Discord
+
+### **En Tu PC** 💻
+Sigue estos pasos para compartir tu pantalla en Discord desde tu PC.
+
+**Paso 1:**
+Selecciona tu <a href="https://discord.gg/R4s2ykDN" class="button-link" target="_blank">**Servidor de Discord Skatehive**</a>.
+
+![Seleccionar Servidor de Discord](https://hackmd.io/_uploads/SkscTAFLA.png)
+
+---
+
+**Paso 2:**
+Haz clic en el ícono de **Compartir Pantalla**.
+
+![Ícono de Compartir Pantalla](https://hackmd.io/_uploads/rkgRRRY8R.png)
+
+---
+
+**Paso 3:**
+Haz clic en el botón **Pantalla** y luego selecciona **Pantalla Completa**.
+
+![Seleccionar Pantalla Completa](https://hackmd.io/_uploads/BJ40ek58A.png)
+
+---
+
+**Paso 4:**
+Elige la mejor resolución de pantalla para compartir y luego haz clic en el botón **Transmitir en Vivo**.
+
+![Seleccionar Resolución de Pantalla](https://hackmd.io/_uploads/Sku6fk5UR.png)
+
+---
+
+**Paso 5:**
+🎉 ¡Ahora estás compartiendo tu pantalla!
+
+![Pantalla Compartida Activa](https://hackmd.io/_uploads/H1XcXyc8A.png)
+
+---
+
+### **En Tu Móvil** 📱
+
+**Paso 1:**
+Selecciona tu <a href="https://discord.gg/R4s2ykDN" class="button-link" target="_blank">**Servidor de Discord Skatehive**</a>.
+
+![Seleccionar Servidor de Discord en Móvil](https://hackmd.io/_uploads/SJjhGQ9UC.jpg)
+
+---
+
+**Paso 2:**
+Desliza la barra de menú inferior hacia arriba.
+
+![Barra de Menú Inferior](https://hackmd.io/_uploads/HkHtmX58C.jpg)
+
+---
+
+**Paso 3:**
+Selecciona **Compartir Tu Pantalla**.
+
+![Opción de Compartir Pantalla en Móvil](https://hackmd.io/_uploads/H1kWHQqLA.jpg)
+
+---
+
+**Paso 4:**
+Toca **Iniciar Ahora** para comenzar a compartir.
+
+![Iniciar Compartir Pantalla en Móvil](https://hackmd.io/_uploads/ryWj8QqU0.jpg)
+
+---
+
+# 🎉 ¿Necesitas Ayuda? ⌐◨-◨
+
+![Ayuda](https://hackmd.io/_uploads/r1uA0QcI0.gif)

--- a/i18n/es/docusaurus-plugin-content-docs/current/Level - 1/hive-wallet.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/Level - 1/hive-wallet.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 2
+---
+
+# Billetera Hive
+
+### **1. Instalar Hive Keychain**  
+- **En Chrome:** Ve a la [Chrome Web Store](https://chrome.google.com/webstore/detail/hive-keychain/jcacnejopjdphbnjgfaaobbfafkihpep) y busca "Hive Keychain." Haz clic en **"Agregar a Chrome"**.  
+- **En Firefox:** Descárgalo desde el sitio oficial de [Hive Keychain](https://hive-keychain.com).  
+![alt text](image.png)
+
+### **2. Configurar la Billetera**  
+- Después de instalar, haz clic en el ícono de Hive Keychain en tu navegador.  
+- Crea una contraseña para asegurar tu billetera.  
+
+![Image](https://ipfs.skatehive.app/ipfs/QmVavmvptLv455oWxdxnuunnoyiMsZU4M66BPSoNBL8rKv)
+
+### **3. Agregar Tu Cuenta Hive**  
+- Haz clic en **"Usar Claves"**.  
+![Image](https://ipfs.skatehive.app/ipfs/QmY6ePRFSBL2ZzN17p23sBPKt197BNtEk5K3kqa8VTdBb2)  
+
+- Ingresa tu nombre de usuario de Hive.  
+- Pega tu clave privada (se recomienda usar la "Clave Activa" para transacciones y la "Clave de Publicación" para interacciones).  
+
+### **4. ¡Listo! Ahora Puedes:**  
+✅ Iniciar sesión en aplicaciones Hive con un clic.  
+✅ Enviar y recibir tokens HIVE y HBD.  
+✅ Administrar múltiples cuentas Hive de manera segura.  
+
+### **Consejos de Seguridad:**  
+🔹 Nunca compartas tus claves privadas.  
+🔹 Guarda tus claves en un lugar seguro.  
+🔹 Siempre descarga Hive Keychain desde fuentes oficiales.  
+
+Ahora puedes usar Hive más fácilmente! ehehe 🚀 

--- a/i18n/es/docusaurus-plugin-content-docs/current/Level - 1/nftskatehive.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/Level - 1/nftskatehive.md
@@ -1,0 +1,75 @@
+---
+title: Skatehive NFT
+sidebar_position: 6
+---
+
+
+### **1. ¿Qué es NounsBuilder?**  
+NounsBuilder es una herramienta que permite la creación de proyectos inspirados en el modelo de **Nouns**, un proyecto de NFT conocido por su enfoque de subasta continua y gobernanza comunitaria. Proporciona un marco modular para crear NFTs con características únicas y subastas periódicas.  
+
+---
+
+### **2. ¿Cómo Funciona la Subasta de NFTs de Skatehive?**  
+La subasta de Skatehive sigue un modelo similar al de Nouns, con adaptaciones específicas para la comunidad de skate. Aquí están los aspectos clave:  
+
+#### **a) Creación de NFTs**  
+- Cada NFT se genera programáticamente combinando diferentes características almacenadas en un repositorio on-chain.  
+
+![Image](https://ipfs.skatehive.app/ipfs/Qmc7U3gvJmnVx99PPBA9dz3NZwx5pLsE6viwqiJttHiGSg)  
+
+- Estas características pueden incluir diseños de patinetas, tablas, ruedas, grafitis u otros elementos visuales relacionados con el skate.  
+- El proceso de creación es totalmente autónomo a través de un contrato inteligente, asegurando que cada NFT sea único.  
+
+#### **b) Subastas Continuas**  
+- Los NFTs se subastan en un proceso continuo, con una nueva subasta comenzando inmediatamente después de que finalice la anterior.  
+- Cada subasta tiene una duración fija (por ejemplo, 24 horas).  
+- Los participantes hacen ofertas en criptomonedas (como ETH) para adquirir el NFT.  
+
+#### **c) Distribución de Fondos**  
+- Los fondos recaudados a través de las subastas se distribuyen de acuerdo con las reglas del contrato inteligente:  
+  - Actualmente, todos los ingresos van al **Tesoro de la Comunidad**, que puede usarse para financiar proyectos, eventos o iniciativas relacionadas con el skate.  
+
+#### **d) Gobernanza Descentralizada**  
+- Los poseedores de NFTs de Skatehive tienen derechos de gobernanza, lo que les permite participar en la toma de decisiones sobre el futuro del proyecto.  
+- Por ejemplo, pueden votar sobre propuestas para asignar fondos del tesoro o agregar nuevas características a los NFTs.  
+
+![Image](https://ipfs.skatehive.app/ipfs/Qme3d63w91sR6uMGCbJSdjQU3sKhNJ9gYj9fwP1WUAZGto)  
+
+---
+
+### **3. Participando en la Subasta**  
+Para participar en la subasta, los usuarios deben:  
+1. Conectar su billetera de criptomonedas (como MetaMask) a la plataforma Skatehive.  
+2. Hacer ofertas durante el período de la subasta.  
+3. Si tienen la oferta más alta al final de la subasta, recibirán el NFT en su billetera.  
+
+---
+
+### **4. Beneficios de los NFTs de Skatehive**  
+- **Exclusividad**: Cada NFT es único y puede apreciarse en valor con el tiempo.  
+- **Comunidad**: Los poseedores se convierten en parte de una comunidad comprometida y tienen voz en la toma de decisiones.  
+- **Apoyo al Skate**: Una parte de los fondos se reinvierte en iniciativas de skate, promoviendo la cultura y el deporte.  
+
+---
+
+### **5. Tecnología Subyacente**  
+- **Contratos Inteligentes**: Toda la lógica de creación, subasta y distribución se ejecuta a través de contratos inteligentes en la blockchain (generalmente Ethereum o una Layer 2 como Base).  
+- **Transparencia**: Todas las transacciones y reglas son públicas y verificables en la blockchain.  
+- **Interoperabilidad**: Los NFTs pueden negociarse en mercados como OpenSea o Blur.  
+
+---
+
+### **6. Flujo de Ejemplo**  
+1. Se genera un nuevo NFT con características únicas.  
+2. La subasta comienza y dura 24 horas.  
+3. Los usuarios hacen ofertas.  
+4. Al final de la subasta, la oferta más alta gana y el NFT se transfiere a la billetera del ganador.  
+5. Los fondos se distribuyen de acuerdo con las reglas del contrato inteligente.  
+6. Una nueva subasta comienza inmediatamente.  
+
+---
+
+### **7. Consideraciones Finales**  
+La subasta de NFTs de Skatehive en NounsBuilder es una forma innovadora de involucrar a la comunidad de skate, crear valor para los participantes y financiar iniciativas significativas. La transparencia y la descentralización aseguran que todos los involucrados tengan voz y reciban beneficios justos.  
+
+Si necesitas más detalles técnicos o ejemplos específicos, ¡solo avísame! 🛹  

--- a/i18n/es/docusaurus-plugin-content-docs/current/Level - 1/telainicial.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/Level - 1/telainicial.md
@@ -1,0 +1,30 @@
+# Cómo agregar Skatehive a la pantalla de inicio de tu teléfono
+
+Agregar Skatehive a la pantalla de inicio de tu teléfono facilita el acceso rápido a la plataforma, como si fuera una aplicación.
+
+## Paso 1: Visita Skatehive
+Abre el navegador de tu teléfono y ve a:
+👉 [Skatehive.app](https://skatehive.app)
+
+## Paso 2: Abre las opciones del navegador
+En la esquina superior derecha (o inferior, dependiendo de tu navegador), toca el ícono de tres puntos o el botón de compartir para abrir el menú de opciones.
+
+## Android
+
+![Image](https://ipfs.skatehive.app/ipfs/QmQVewpaK4iJgqqyXFPMTuJ32ihvS9B7bHbTyAhMFWZzju)
+
+## iOS
+
+![Image](https://ipfs.skatehive.app/ipfs/QmQVzMQn7iDFEns8jDZjZtVMzYPhBWHhv4KJLJc4ghqU4v)
+
+## Paso 3: Agregar a la pantalla de inicio
+En el menú que aparece, selecciona **"Agregar a la pantalla de inicio"**.
+
+## Paso 4: Confirma la acción
+Tu navegador puede pedirte que elijas un nombre para el acceso directo. Puedes mantener **"Skatehive"** o cambiarlo como prefieras. Luego, toca **"Agregar"**.
+
+¡Listo! Ahora, Skatehive estará en la pantalla de inicio de tu teléfono como un ícono, haciendo que el acceso sea mucho más rápido y fácil. 🛹🔥
+
+---
+
+¡Déjame saber si necesitas algún cambio o mejora! 😊

--- a/i18n/es/docusaurus-plugin-content-docs/current/Level - 2/congratulations.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/Level - 2/congratulations.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 4
+---
+
+# ¡Felicidades! 🎉
+
+¡Felicidades por completar los tutoriales de Skatehive! 🎉
+
+Ahora estás completamente equipado para sumergirte en el emocionante mundo de **Skatehive**. ¡Es hora de mostrar tus mejores trucos 🛹 e incluso comenzar a ganar recompensas por tus esfuerzos! 🤑
+
+### ¿Qué sigue?
+- **Publica tus trucos:** Sube tus mejores movimientos de skate a la plataforma Skatehive y hazte notar por la comunidad.
+- **Obtén recompensas:** Comienza a ganar recompensas publicando contenido, interactuando con otros y participando en el ecosistema.
+- **Mantente activo:** Sigue publicando e interactuando para aumentar tus recompensas y visibilidad.
+
+Ahora que estás listo, dirígete a <a href="https://skatehive.app/" class="button-link" target="_blank">**Webite Skatehive**</a> y comienza a crear!
+
+¡Nos vemos en la plataforma! 👋

--- a/i18n/es/docusaurus-plugin-content-docs/current/Level - 2/eth-wallet.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/Level - 2/eth-wallet.md
@@ -1,0 +1,120 @@
+---
+sidebar_position: 1
+---
+
+# Billetera Ethereum (Zerion)
+
+### Introducción
+La **Billetera Zerion** es una herramienta versátil diseñada para gestionar tus activos de Ethereum y multi-cadena. Ofrece intercambios de tokens sin problemas, admite soluciones de Capa 2 para tarifas de transacción más bajas y ofrece una interfaz fácil de usar. En esta guía, te guiaremos a través del proceso de creación y configuración de tu **Billetera Zerion**.
+
+Aunque también están disponibles otras billeteras de Ethereum como **MetaMask** y **Trust Wallet**, Zerion se destaca por su integración sin problemas y soporte para múltiples redes blockchain. Es una excelente opción tanto para principiantes como para usuarios experimentados.
+
+---
+
+### Instalación de la Extensión del Navegador
+
+# Paso 1: Visita <a href="https://zerion.io/download" class="button-link" target="_blank">**Website Zerion.io**</a>
+
+Ve al sitio web de Zerion para descargar la extensión del navegador.
+
+# Paso 2: Elige tu Extensión de Navegador
+Selecciona la extensión adecuada para tu navegador.
+
+![zerion1](https://hackmd.io/_uploads/BJEu_hgI0.png)
+
+# Paso 3: Confirma la Adición de la Extensión
+Después de elegir la extensión, confirma su adición a tu navegador.
+
+![zerion2](https://hackmd.io/_uploads/B1p1Jpg80.png)
+
+---
+
+### Creación de una Billetera
+
+# Paso 1: Haz clic en el Icono de la Extensión de la Billetera Zerion
+En tu navegador, haz clic en el icono de la extensión de la Billetera Zerion.
+
+# Paso 2: Haz clic en **Crear Nueva Billetera**
+Inicia el proceso de creación de la billetera haciendo clic en el botón **Crear Nueva Billetera**.
+
+![zerion3](https://hackmd.io/_uploads/HJJ1bpgUR.png)
+
+---
+
+### Configuración de la Billetera
+
+# Paso 1: Configura un PIN o Contraseña
+**Esta contraseña desbloqueará la Billetera Zerion en tu navegador.**
+
+- **¿Por qué necesito una contraseña?**
+  - Esta contraseña se utiliza para desbloquear tu billetera Zerion al conectarte a aplicaciones descentralizadas (dApps) o firmar transacciones.
+
+![Screenshot from 2024-06-19 17-43-09](https://hackmd.io/_uploads/Hy8bQplUC.png)
+
+# Paso 2: Confirma tu Contraseña
+Confirma tu contraseña ingresándola nuevamente.
+
+![Screenshot from 2024-06-19 17-49-23](https://hackmd.io/_uploads/Sk__Epx8R.png)
+
+# Paso 3: Anota tu Frase de Recuperación
+**Tu frase de recuperación es la única forma de acceder a tus cuentas y activos**, incluso si olvidas tu contraseña.
+
+- **Nunca compartas tu frase de recuperación o contraseña con nadie**, incluidos los miembros del equipo de Zerion.
+
+![zerion4.png](https://hackmd.io/_uploads/rJc9U6gLC.png)
+
+# Paso 4: Visualiza y Anota tu Frase de Recuperación
+Haz clic en el ojo para revelar tu frase de recuperación y **anótala en papel**. ¡Guárdala en un lugar seguro!
+
+![zerion5](https://hackmd.io/_uploads/HJuvhalL0.png)
+
+# Paso 5: Verifica tu Frase de Recuperación
+Este paso asegura que hayas guardado correctamente tu frase de recuperación.
+
+![Screenshot from 2024-06-19 18-37-44](https://hackmd.io/_uploads/SJHUXReUR.png)
+
+---
+
+### Fija la Extensión en tu Navegador
+
+Haz clic en el icono de la extensión de Zerion en tu navegador y luego haz clic en el **botón de pin**.
+
+![zerion6](https://hackmd.io/_uploads/HJ4F4ReUA.png)
+
+---
+
+### Paso 6: ¡Billetera Configurada con Éxito!
+¡Felicidades, tu billetera Zerion ahora está lista para usar!
+
+![Screenshot from 2024-06-19 18-39-58](https://hackmd.io/_uploads/HyBoSAgIA.png)
+
+---
+
+### 🛹 Ve a [skatehive.app](https://www.skatehive.app/) 🛹
+
+# Paso 1: Edita tu Perfil
+Haz clic en "Editar Perfil" para actualizar tu cuenta.
+
+![skthive1](https://hackmd.io/_uploads/B1mnon_IR.png)
+
+# Paso 2: Agrega tu Dirección de Billetera Ethereum
+Haz clic en **Agregar Dirección de Billetera Ethereum** y confirma la transacción en tu billetera Zerion.
+
+![skthive2](https://hackmd.io/_uploads/HyrJbkK8R.png)
+
+# Paso 3: Confirma tu Dirección de Billetera
+Verifica tu dirección de billetera y haz clic en **Confirmar Dirección**.
+
+![skthive3](https://hackmd.io/_uploads/HkBLWJY8R.png)
+
+# Paso 4: Guarda los Cambios
+Una vez que hayas confirmado tu dirección de billetera, haz clic en **Guardar Cambios**.
+
+![skthive4](https://hackmd.io/_uploads/rkH1Q1tIA.png)
+
+---
+
+### ¡Todo Listo! 🎉
+¡Ahora estás listo para recibir recompensas en Skatehive!
+
+![nounsequiperocket](https://hackmd.io/_uploads/B1kSOkGIC.gif)

--- a/i18n/es/docusaurus-plugin-content-docs/current/Level - 2/hive-witness.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/Level - 2/hive-witness.md
@@ -1,0 +1,59 @@
+---
+title: Testigo de Hive
+sidebar_position: 9
+---
+
+# Cómo Votar por el Testigo de Skatehive en la Blockchain de Hive
+
+La Blockchain de Hive es una plataforma descentralizada que opera con testigos para mantener la red segura y funcional. Votar por un testigo, como Skatehive, ayuda a apoyar iniciativas que promueven la cultura del skate y la descentralización. Este tutorial te guiará a través del proceso.
+
+---
+
+#### Paso 1: Inicia sesión en un Cliente de Hive
+**Para votar, necesitarás un cliente de Hive, como:**
+- **Hive Keychain**: Una extensión de navegador para gestionar cuentas.
+- **Ecency**: Una plataforma amigable para interactuar con Hive.
+- **PeakD**: Una interfaz avanzada para usuarios de Hive.
+
+Descarga e instala la extensión Hive Keychain (si aún no lo has hecho) e inicia sesión con tus credenciales.
+
+---
+
+#### Paso 2: Accede a la Página de Votación de Testigos
+1. Ve a [PeakD](https://peakd.com) o [Hive Blog](https://hive.blog).
+2. Haz clic en el menú o busca la opción "Testigos".
+   - En PeakD, está en la barra lateral izquierda.
+   - En Hive Blog, puedes acceder directamente al enlace: [https://hive.blog/~witnesses](https://hive.blog/~witnesses).
+
+![](https://i.ibb.co/ZhFv3bY/image.png)
+---
+
+#### Paso 3: Encuentra el Testigo de Skatehive
+1. En la lista de testigos, busca **Skatehive**.
+   - Usa la barra de búsqueda (Ctrl + F en tu teclado) y escribe "skatehive".
+2. Si no lo encuentras, usa el enlace directo para votar: [https://peakd.com/me/witnesses](https://peakd.com/me/witnesses) y añade manualmente el nombre del testigo `skatehive`.
+![](https://i.ibb.co/M7frCxC/image.png)
+
+---
+
+#### Paso 4: Vota por Skatehive
+1. Haz clic en el botón de votar junto al nombre de Skatehive.
+2. Confirma tu acción:
+   - Si usas Hive Keychain, te pedirá que autorices la transacción.
+   - Confirma e ingresa tu clave de acceso (si es necesario).
+
+---
+
+#### Paso 5: Verifica tu Voto
+**Después de votar:**
+1. Verifica que Skatehive aparezca en tu lista de votos activos.
+2. Puedes hacerlo en la misma página de testigos o en la pestaña de configuración de tu cuenta.
+
+---
+
+### Consejos Finales
+- **¿Por qué votar por Skatehive?** Skatehive es un testigo que promueve la comunidad del skate en la Blockchain de Hive, fomentando la descentralización y la creatividad.
+- **Límite de votos**: Cada cuenta puede votar por hasta 30 testigos. Usa tus votos sabiamente.
+- **Involúcrate**: Únete a la comunidad de Skatehive y ayuda a fortalecer el proyecto.
+
+Ahora que sabes cómo votar, apoya a Skatehive y sé parte de esta increíble comunidad! 🛹

--- a/i18n/es/docusaurus-plugin-content-docs/current/create-account.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/create-account.mdx
@@ -1,0 +1,154 @@
+---
+position: 1
+title: Crear Cuenta
+---
+# Cómo Crear una Cuenta en Skatehive
+
+
+<div style={{
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  margin: '20px 0'
+}}>
+<video width="600" controls>
+  <source src="https://ipfs.skatehive.app/ipfs/QmYuM1h51bddDuC44FoAQYp9FRF2CghCncULeS4T3bp727" type="video/mp4" />
+  Su navegador no soporta la etiqueta de vídeo.
+</video>
+</div>
+
+## 1. Refiere a un Amigo a Skatehive Usando Tu Cuenta
+
+1. **Navega hasta el ícono del robot** en la parte superior de Skatehive o [haz clic aquí](https://www.skatehive.app/invite).  
+
+<img src="https://i.ibb.co/JCCj9Sf/image.png" alt="Navega hasta el Ícono del Robot" width="150" />
+
+2. **Elige su nombre de usuario**. Asegúrate de que le guste, ya que no se puede cambiar fácilmente. Escribe su dirección de correo electrónico.  
+![Ingresa el Nombre de Usuario y Correo Electrónico](https://hackmd.io/_uploads/H1tZGNP1Jx.png)
+
+3. Una vez que hagas clic en **"Parece Bien, Adelante"**, se solicitará una transacción en Keychain. Después de aprobar, se creará la cuenta y tu amigo recibirá un correo electrónico.
+
+---
+
+## Recibe una Invitación por Correo Electrónico
+
+Tu amigo recibirá un correo electrónico que contiene sus **CLAVES HIVE**.  
+![Correo Electrónico de Claves Hive](https://ipfs.skatehive.app/ipfs/QmbTbULhRtAfyd19cTNYfrsjpsuRN2TV9sxZ5yzQQeR44D)
+
+### Importante: Mantén Tus Claves Seguras
+- **¡Nunca pierdas tus claves!** No se pueden recuperar si se pierden.
+- Skatehive.app no almacena copias de tus claves por razones de seguridad. Es tu responsabilidad almacenarlas de manera segura.
+
+### Iniciando Sesión
+Usa tu nombre de usuario y contraseña para iniciar sesión en Skatehive a través de cualquier navegador. Sin embargo, recomendamos usar **Hive Keychain** para la experiencia más segura.
+
+#### Opciones de Hive Keychain para Móvil
+
+<div style={{ display: 'flex', justifyContent: 'center' }}>
+
+
+| iOS  | Android |
+| -------- | -------- |
+| ![](https://hive-keychain.com/img/browsers/ios.svg) | ![](https://hive-keychain.com/img/browsers/android.svg) |  
+
+</div>
+
+#### Opciones de Hive Keychain para Escritorio
+
+<div style={{
+  display: 'flex', 
+  justifyContent: 'center', 
+  backgroundColor: 'var(--ifm-color-background)', 
+  padding: '20px', 
+  borderRadius: '8px',
+  color: 'var(--text-color)'
+}}>
+  <table style={{
+    textAlign: 'center', 
+    borderSpacing: '16px', 
+    color: 'inherit'
+  }}>
+    <thead>
+      <tr>
+        <th style={{ color: 'inherit' }}>Chrome</th>
+        <th style={{ color: 'inherit' }}>Brave</th>
+        <th style={{ color: 'inherit' }}>Firefox</th>
+      </tr>
+    </thead>
+    <tbody style={{ backgroundColor: '#808080'}}>
+      <tr>
+        <td style={{
+          padding: '10px', 
+          borderRadius: '8px',
+          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)'
+        }}>
+          <img 
+            src="https://hive-keychain.com/img/browsers/chrome.svg" 
+            alt="Chrome" 
+            style={{
+              maxWidth: '60px',
+              borderRadius: '8px'
+            }}
+          />
+        </td>
+        <td style={{
+          padding: '10px', 
+          borderRadius: '8px',
+          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)'
+        }}>
+          <img 
+            src="https://hive-keychain.com/img/browsers/brave.svg" 
+            alt="Brave" 
+            style={{
+              maxWidth: '60px',
+              borderRadius: '8px'
+            }}
+          />
+        </td>
+        <td style={{
+          padding: '10px', 
+          borderRadius: '8px',
+          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)'
+        }}>
+          <img 
+            src="https://hive-keychain.com/img/browsers/firefox.svg" 
+            alt="Firefox" 
+            style={{
+              maxWidth: '60px',
+              borderRadius: '8px'
+            }}
+          />
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+---
+
+## 2. Configurando Hive Keychain
+
+**Hive Keychain** almacena de manera segura tu información de clave privada. Está disponible como una extensión de navegador para escritorio y como una aplicación móvil (que también sirve como navegador web). Úsalo para iniciar sesión en los frontends de Hive, incluido Skatehive.
+
+### Para Usuarios Móviles
+1. Crea un PIN para desbloquear el keychain.
+   ![Establecer PIN](https://hackmd.io/_uploads/rk9Y1SDJJg.png)
+
+2. Después de configurar el PIN, haz clic en **Usar Claves/Contraseña** e ingresa tu **Contraseña Maestra**.  
+   ![Ingresa la Contraseña Maestra](https://hackmd.io/_uploads/HyBYyBwJJg.png)
+
+3. Inicia sesión en Skatehive ingresando tu **nombre de usuario**.  
+   ![Iniciar Sesión en Skatehive](https://hackmd.io/_uploads/ByGmlHDkJl.png)
+
+Una vez que Hive Keychain apruebe la transacción, estarás conectado.
+
+---
+
+## 3. Crea una Cuenta Hive Tú Mismo
+
+También puedes crear cuentas Hive (carteras) usando otros frontends de Hive y luego usar esas cuentas para iniciar sesión en Skatehive.
+
+### Pasos:
+1. Asegúrate de tener **Hive Keychain** instalado.
+2. Ve a [HiveOnboard](https://hiveonboard.com/create-account) y crea tu cuenta.
+

--- a/i18n/fr/docusaurus-plugin-content-docs/current/Level - 0/fork-skatehive.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/Level - 0/fork-skatehive.md
@@ -1,0 +1,247 @@
+---
+title: Guide de Fork Skatehive
+sidebar_position: 1
+---
+
+# Comment Fork Skatehive 🛹
+
+Nous allons faire ce tutoriel pour tous ceux qui veulent créer leur propre portail alimenté par Skatehive, comme <a href="https://skatehive.app" class="button-link" target="_blank">**Skatehive.app**</a>.
+
+Vous allez devoir installer certaines choses sur votre machine pour préparer votre environnement de développement.
+
+Le code est encore un peu désordonné, mais je vous invite à faire partie de ce voyage d'apprentissage avec nous. Ce document sera toujours mis à jour à : https://docs.skatehive.app
+
+## Index
+
+- Installer Git et configurer le compte Github
+- Configurer les clés SSH de Github
+- Forker le Répertoire 
+- Cloner/Télécharger le Répertoire
+- Télécharger et Installer NodeJs
+- Installer pnpm 
+- Installer les Dépendances avec `pnpm`
+- Changer les variables .env
+- Exécuter avec `pnpm dev`
+- Apporter quelques modifications juste pour le plaisir
+- Pousser vos modifications sur github 
+- Mettre en ligne, déployer votre version avec vercel 
+
+
+## Installer Git et configurer le compte Github
+
+Téléchargez et installez Git sur votre machine locale. Cela vous permettra d'exécuter des commandes git dans votre terminal, comme `git clone` et d'autres magies 
+
+
+[Télécharger Git](https://git-scm.com/downloads)
+[En savoir plus sur git et son installation](https://www.youtube.com/results?search_query=what+is+git+how+to+install)
+
+## Créer un compte Github
+
+Il suffit de s'inscrire 
+
+## Configurer les clés SSH de Github 
+
+Pour rendre le processus plus fluide, nous allons configurer une connexion SSH en générant des clés SSH. 
+
+
+1. Ouvrez votre terminal 
+
+2. Tapez la commande suivante
+> utilisez le même email que vous avez utilisé pour créer le compte github
+
+```
+ssh-keygen -t ed25519 -C "your_email@example.com"
+``` 
+> Cela crée une nouvelle clé SSH, en utilisant l'email fourni comme étiquette.
+
+3. Démarrez l'agent ssh en arrière-plan
+
+```
+eval "$(ssh-agent -s)"
+```
+
+4. Copiez le contenu du fichier id_ed25519.pub dans votre presse-papiers
+
+- Pour les utilisateurs de Mac : 
+`pbcopy < ~/.ssh/id_ed25519.pub`
+
+- Pour les utilisateurs de Windows : 
+`clip < ~/.ssh/id_ed25519.pub`
+
+
+
+et donnez-lui un titre et collez le contenu dans Key
+![Alt ​​text](../../src/assets/Tuto-Dev/1.png)
+
+
+
+> [Tutoriel complet SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
+
+## Forker le répertoire
+
+ **[Cliquez sur le bouton Fork](https://github.com/SkateHive/nextskateapp)** 
+
+![Alt ​​text](../../src/assets/Tuto-Dev/2.png)
+
+Cela créera votre propre version du répertoire dans votre compte : 
+
+![Alt ​​text](../../src/assets/Tuto-Dev/3.png)
+
+Ok, maintenant vous allez cloner le répertoire de fichiers dans votre machine, ce qui revient à télécharger l'application : 
+
+```
+git clone git@github.com:<your-username>/<your-fork>.git
+```
+
+![Alt ​​text](../../src/assets/Tuto-Dev/4.png)
+
+
+Maintenant, naviguez vers le répertoire cloné par : 
+
+```
+cd <your-fork>
+```
+
+Dans ce cas, 
+
+```
+cd nextskateapp
+``` 
+
+Pour l'étape suivante, nous allons devoir installer quelques programmes supplémentaires sur votre machine pour compléter votre environnement et enfin installer et exécuter l'application. 
+
+
+## [Télécharger et installer Node.Js](https://nodejs.org/en)
+
+> Rien de spécial ici, il suffit d'installer et de s'assurer de laisser l'option `add to path` cochée.
+
+## [Installer pnpm ici](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) ou 
+
+```
+npm install -g pnpm
+```
+
+> [Plus de façons d'installer Yarn](https://www.youtube.com/results?search_query=install+yarn)
+
+
+Si vous avez Nodejs, npm, yarn et weed/coffee, vous pouvez maintenant l'installer et l'exécuter sur votre machine locale. 
+
+## Retour au terminal... 
+
+Dans le dossier du répertoire
+
+```
+pnpm i
+```
+> Remarque : Cette commande installera automatiquement tous les packages JavaScript et dépendances nécessaires pour votre projet, comme spécifié dans le fichier package.json. Yarn téléchargera et configurera tout ce qui est nécessaire pour exécuter votre portail Skatehive.
+Cette étape garantit que vous disposez de toutes les bibliothèques et outils nécessaires dans votre environnement de développement pour construire et exécuter l'application.
+
+
+![Alt ​​text](../../src/assets/Tuto-Dev/5.png)
+Attendez un peu, buvez du "café"...
+
+Vous devriez voir cela lorsque c'est terminé : 
+![Alt ​​text](../../src/assets/Tuto-Dev/6.png)
+
+> Si vous rencontrez une erreur à n'importe quelle étape, vous pouvez la lancer dans chat-gpt ou nous demander sur [skatehive discord](https://discord.gg/skatehive) et voir lequel vous aide le plus rapidement 
+
+
+## Renommer .env.example en .env 
+
+Renommez .env.example et choisissez la communauté hive à partir de laquelle vous souhaitez obtenir/télécharger du contenu. Par exemple, si vous utilisez hive-173115, vous obtenez skatehive, si vous utilisez hive-141964 dans le champ communauté, vous obtenez surfhive 
+
+## .env.example
+NEXT_PUBLIC_WEBSITE_URL=http://localhost:3000/
+NEXT_PUBLIC_HIVE_COMMUNITY_TAG=xxxxxxxxxxx
+NEXT_PUBLIC_PINATA_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NEXT_PUBLIC_PINATA_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NEXT_PUBLIC_PINATA_GATEWAY_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NEXT_PUBLIC_CRYPTO_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NEXT_PUBLIC_OPENAI_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NEXT_PUBLIC_ETHERSCAN_API=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+Maintenant, exécutez l'application que vous venez d'installer : 
+
+```
+pnpm dev
+```
+![Alt ​​text](../../src/assets/Tuto-Dev/7.png)
+
+
+Maintenant, ouvrez https://localhost:3000 <a href="https://skatehive.app" class="button-link" target="_blank"></a> et vous verrez la même application que <a href="https://skatehive.app" class="button-link" target="_blank">**Website Skatehive**</a>.
+
+![Alt ​​text](../../src/assets/Tuto-Dev/8.png)
+
+Cela signifie que vous exécutez l'application en utilisant votre propre ordinateur comme serveur via le port 3000 
+
+Vous pouvez maintenant essayer d'éditer votre code dans un éditeur de code, je recommande <a href="https://code.visualstudio.com/" class="button-link" target="_blank">**Website VSCode**</a>, mais mon maître Jedi recommande <a href="https://www.jetbrains.com/" class="button-link" target="_blank">**Website JetBrains**</a>.
+
+
+J'utilise généralement la commande `code .` dans le dossier du terminal pour ouvrir facilement le dossier sur lequel je travaille dans VScode
+
+Faites un changement idiot, comme changer le pied de page.
+
+![Alt ​​text](../../src/assets/Tuto-Dev/9.png)
+
+
+Ce projet est construit avec TypeScript et intègre Chakra UI pour le frontend. Pour les tâches liées à Hive, nous nous appuyons sur le <a href="https://play.hive-keychain.com/" class="button-link" target="_blank">**Website Keychain SDK**</a> et les bibliothèques dive. De plus, pour faciliter les interactions avec Ethereum, Bitcoin et diverses autres blockchains, nous tirons parti des capacités de <a href="https://github.com/BitHighlander/pioneer-react#readme" class="button-link" target="_blank">**WebSite Pioneer-React**</a>.
+
+
+
+**Stage Changes:**
+
+Avant d'envoyer sur github, il est bon de : 
+
+```
+pnpm build:turbo 
+```
+
+et tester sa build localement !
+
+```
+git add .
+````
+> pour préparer vos modifications pour le commit.
+
+**Commit Changes:**
+
+```
+git commit -m "Changed header color".
+```
+> Commit avec un message 
+
+**Push to GitHub:**
+```
+git push origin main
+```
+> Poussez vos modifications 
+
+Vous pouvez maintenant aller sur votre compte github et vérifier si cela a été mis à jour 
+
+## Mettre votre site web en ligne 
+
+## Allez sur vercel.com 
+
+1. Créez un compte avec votre compte github 
+![Alt ​​text](../../src/assets/Tuto-Dev/10.png)
+
+2. Installez l'extension Github qu'il propose 
+3. Sélectionnez le répertoire 
+![Alt ​​text](../../src/assets/Tuto-Dev/11.png)
+
+4. Cliquez sur Déployer
+
+Vous devriez voir quelque chose comme ça : 
+
+![Alt ​​text](../../src/assets/Tuto-Dev/12.png)
+ 
+
+Vous pouvez maintenant naviguer vers : 
+
+https://your-repo.vercel.app 
+
+et voir votre propre communauté hive. 
+
+Félicitations ! C'est tellement cool, vous avez mis un site web en ligne sans autorisation ! Allez montrer ça à votre maman, dites-lui qu'elle me manque. 
+
+--- 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/Level - 1/Discord-Share-Screen.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/Level - 1/Discord-Share-Screen.md
@@ -1,0 +1,73 @@
+# Comment partager votre écran Discord
+
+### **Sur votre PC** 💻
+Suivez ces étapes pour partager votre écran sur Discord depuis votre PC.
+
+**Étape 1 :**
+Sélectionnez votre <a href="https://discord.gg/R4s2ykDN" class="button-link" target="_blank">**Serveur Discord Skatehive**</a>.
+
+![Sélectionner le serveur Discord](https://hackmd.io/_uploads/SkscTAFLA.png)
+
+---
+
+**Étape 2 :**
+Cliquez sur l'icône **Partager l'écran**.
+
+![Icône de partage d'écran](https://hackmd.io/_uploads/rkgRRRY8R.png)
+
+---
+
+**Étape 3 :**
+Cliquez sur le bouton **Écran**, puis sélectionnez **Écran entier**.
+
+![Sélectionner l'écran entier](https://hackmd.io/_uploads/BJ40ek58A.png)
+
+---
+
+**Étape 4 :**
+Choisissez la meilleure résolution d'écran pour le partage, puis cliquez sur le bouton **Go Live**.
+
+![Sélectionner la résolution de l'écran](https://hackmd.io/_uploads/Sku6fk5UR.png)
+
+---
+
+**Étape 5 :**
+🎉 Vous partagez maintenant votre écran !
+
+![Partage d'écran actif](https://hackmd.io/_uploads/H1XcXyc8A.png)
+
+---
+
+### **Sur votre mobile** 📱
+
+**Étape 1 :**
+Sélectionnez votre <a href="https://discord.gg/R4s2ykDN" class="button-link" target="_blank">**Serveur Discord Skatehive**</a>.
+
+![Sélectionner le serveur Discord sur mobile](https://hackmd.io/_uploads/SJjhGQ9UC.jpg)
+
+---
+
+**Étape 2 :**
+Faites glisser la barre de menu inférieure vers le haut.
+
+![Barre de menu inférieure](https://hackmd.io/_uploads/HkHtmX58C.jpg)
+
+---
+
+**Étape 3 :**
+Sélectionnez **Partager votre écran**.
+
+![Option de partage d'écran sur mobile](https://hackmd.io/_uploads/H1kWHQqLA.jpg)
+
+---
+
+**Étape 4 :**
+Appuyez sur **Commencer maintenant** pour commencer le partage.
+
+![Commencer le partage d'écran sur mobile](https://hackmd.io/_uploads/ryWj8QqU0.jpg)
+
+---
+
+# 🎉 Besoin d'aide ? ⌐◨-◨
+
+![Aide](https://hackmd.io/_uploads/r1uA0QcI0.gif)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/Level - 1/hive-wallet.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/Level - 1/hive-wallet.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 2
+---
+
+# Portefeuille Hive
+
+### **1. Installer Hive Keychain**  
+- **Sur Chrome :** Allez sur le [Chrome Web Store](https://chrome.google.com/webstore) et recherchez "Hive Keychain". Cliquez sur **"Ajouter à Chrome"**.  
+- **Sur Firefox :** Téléchargez-le depuis le site officiel de [Hive Keychain](https://hive-keychain.com).  
+![alt text](image.png)
+
+### **2. Configurer le Portefeuille**  
+- Après l'installation, cliquez sur l'icône Hive Keychain dans votre navigateur.  
+- Créez un mot de passe pour sécuriser votre portefeuille.  
+
+![Image](https://ipfs.skatehive.app/ipfs/QmVavmvptLv455oWxdxnuunnoyiMsZU4M66BPSoNBL8rKv)
+
+### **3. Ajouter Votre Compte Hive**  
+- Cliquez sur **"Utiliser les Clés"**.  
+![Image](https://ipfs.skatehive.app/ipfs/QmY6ePRFSBL2ZzN17p23sBPKt197BNtEk5K3kqa8VTdBb2)  
+
+- Entrez votre nom d'utilisateur Hive.  
+- Collez votre clé privée (il est recommandé d'utiliser la "Clé Active" pour les transactions et la "Clé de Publication" pour les interactions).  
+
+### **4. Terminé ! Vous Pouvez Maintenant :**  
+✅ Vous connecter aux applications Hive en un clic.  
+✅ Envoyer et recevoir des tokens HIVE et HBD.  
+✅ Gérer plusieurs comptes Hive en toute sécurité.  
+
+### **Conseils de Sécurité :**  
+🔹 Ne partagez jamais vos clés privées.  
+🔹 Conservez vos clés en lieu sûr.  
+🔹 Téléchargez toujours Hive Keychain à partir de sources officielles.  
+
+Vous pouvez maintenant utiliser Hive plus facilement ! ehehe 🚀 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/Level - 1/nftskatehive.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/Level - 1/nftskatehive.md
@@ -1,0 +1,75 @@
+---
+title: Skatehive NFT
+sidebar_position: 6
+---
+
+
+### **1. Qu'est-ce que NounsBuilder ?**  
+NounsBuilder est un outil qui permet la création de projets inspirés par le modèle **Nouns**, un projet NFT connu pour son approche de vente aux enchères continue et sa gouvernance communautaire. Il fournit un cadre modulaire pour créer des NFT avec des traits uniques et des enchères périodiques.  
+
+---
+
+### **2. Comment fonctionne la vente aux enchères de NFT de Skatehive ?**  
+La vente aux enchères de Skatehive suit un modèle similaire à celui de Nouns, avec des adaptations spécifiques pour la communauté du skateboard. Voici les aspects clés :  
+
+#### **a) Création de NFT**  
+- Chaque NFT est généré de manière programmatique en combinant différents traits stockés dans un référentiel on-chain.  
+
+![Image](https://ipfs.skatehive.app/ipfs/Qmc7U3gvJmnVx99PPBA9dz3NZwx5pLsE6viwqiJttHiGSg)  
+
+- Ces traits peuvent inclure des designs de skateboards, des planches, des roues, des graffitis ou d'autres éléments visuels liés au skateboard.  
+- Le processus de création est entièrement autonome via un contrat intelligent, garantissant que chaque NFT est unique.  
+
+#### **b) Enchères continues**  
+- Les NFT sont mis aux enchères dans un processus continu, avec une nouvelle enchère commençant immédiatement après la fin de la précédente.  
+- Chaque enchère a une durée fixe (par exemple, 24 heures).  
+- Les participants placent des offres en cryptomonnaie (comme l'ETH) pour acquérir le NFT.  
+
+#### **c) Distribution des fonds**  
+- Les fonds collectés via les enchères sont distribués selon les règles du contrat intelligent :  
+  - Actuellement, tous les fonds vont au **Trésor de la Communauté**, qui peut être utilisé pour financer des projets, des événements ou des initiatives liées au skateboard.  
+
+#### **d) Gouvernance décentralisée**  
+- Les détenteurs de NFT de Skatehive ont des droits de gouvernance, leur permettant de participer à la prise de décision pour l'avenir du projet.  
+- Par exemple, ils peuvent voter sur des propositions pour allouer des fonds du trésor ou ajouter de nouveaux traits aux NFT.  
+
+![Image](https://ipfs.skatehive.app/ipfs/Qme3d63w91sR6uMGCbJSdjQU3sKhNJ9gYj9fwP1WUAZGto)  
+
+---
+
+### **3. Participer à l'enchère**  
+Pour participer à l'enchère, les utilisateurs doivent :  
+1. Connecter leur portefeuille de cryptomonnaie (comme MetaMask) à la plateforme Skatehive.  
+2. Placer des offres pendant la période de l'enchère.  
+3. S'ils ont la plus haute offre à la fin de l'enchère, ils reçoivent le NFT dans leur portefeuille.  
+
+---
+
+### **4. Avantages des NFT de Skatehive**  
+- **Exclusivité** : Chaque NFT est unique et peut prendre de la valeur au fil du temps.  
+- **Communauté** : Les détenteurs deviennent partie intégrante d'une communauté engagée et ont leur mot à dire dans les décisions.  
+- **Soutien au skateboard** : Une partie des fonds est réinvestie dans des initiatives de skateboard, promouvant la culture et le sport.  
+
+---
+
+### **5. Technologie sous-jacente**  
+- **Contrats intelligents** : Toute la logique de création, d'enchère et de distribution est exécutée via des contrats intelligents sur la blockchain (généralement Ethereum ou une Layer 2 comme Base).  
+- **Transparence** : Toutes les transactions et règles sont publiques et vérifiables sur la blockchain.  
+- **Interopérabilité** : Les NFT peuvent être échangés sur des places de marché comme OpenSea ou Blur.  
+
+---
+
+### **6. Exemple de flux**  
+1. Un nouveau NFT est généré avec des traits uniques.  
+2. L'enchère commence et dure 24 heures.  
+3. Les utilisateurs placent des offres.  
+4. À la fin de l'enchère, la plus haute offre gagne et le NFT est transféré dans le portefeuille du gagnant.  
+5. Les fonds sont distribués selon les règles du contrat intelligent.  
+6. Une nouvelle enchère commence immédiatement.  
+
+---
+
+### **7. Considérations finales**  
+La vente aux enchères de NFT de Skatehive sur NounsBuilder est une manière innovante d'engager la communauté du skateboard, de créer de la valeur pour les participants et de financer des initiatives significatives. La transparence et la décentralisation garantissent que tous les participants ont une voix et reçoivent des bénéfices équitables.  
+
+Si vous avez besoin de plus de détails techniques ou d'exemples spécifiques, faites-le moi savoir ! 🛹  

--- a/i18n/fr/docusaurus-plugin-content-docs/current/Level - 1/telainicial.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/Level - 1/telainicial.md
@@ -1,0 +1,30 @@
+# Comment ajouter Skatehive à l'écran d'accueil de votre téléphone
+
+Ajouter Skatehive à l'écran d'accueil de votre téléphone facilite l'accès rapide à la plateforme, comme une application.
+
+## Étape 1 : Visitez Skatehive
+Ouvrez le navigateur de votre téléphone et allez sur :  
+👉 [Skatehive.app](https://skatehive.app)
+
+## Étape 2 : Ouvrez les options du navigateur
+En haut à droite (ou en bas, selon votre navigateur), appuyez sur l'icône à trois points ou sur le bouton de partage pour ouvrir le menu des options.
+
+## Android
+
+![Image](https://ipfs.skatehive.app/ipfs/QmQVewpaK4iJgqqyXFPMTuJ32ihvS9B7bHbTyAhMFWZzju)
+
+## iOS
+
+![Image](https://ipfs.skatehive.app/ipfs/QmQVzMQn7iDFEns8jDZjZtVMzYPhBWHhv4KJLJc4ghqU4v)
+
+## Étape 3 : Ajouter à l'écran d'accueil
+Dans le menu qui apparaît, sélectionnez **"Ajouter à l'écran d'accueil"**.
+
+## Étape 4 : Confirmez l'action
+Votre navigateur peut vous demander de choisir un nom pour le raccourci. Vous pouvez garder **"Skatehive"** ou le changer comme vous le souhaitez. Ensuite, appuyez sur **"Ajouter"**.
+
+C'est fait ! Maintenant, Skatehive sera sur l'écran d'accueil de votre téléphone comme une icône, rendant l'accès beaucoup plus rapide et facile. 🛹🔥
+
+---
+
+Faites-moi savoir si vous avez besoin de modifications ou d'améliorations ! 😊

--- a/i18n/fr/docusaurus-plugin-content-docs/current/Level - 2/congratulations.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/Level - 2/congratulations.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 4
+---
+
+# Félicitations! 🎉
+
+Félicitations pour avoir terminé les tutoriels de Skatehive! 🎉
+
+Vous êtes maintenant pleinement équipé pour plonger dans le monde passionnant de **Skatehive**. Il est temps de montrer vos meilleurs tricks 🛹 et même de commencer à gagner des récompenses pour vos efforts! 🤑
+
+### Et après?
+- **Publiez vos tricks:** Téléchargez vos meilleurs mouvements de skateboard sur la plateforme Skatehive et faites-vous remarquer par la communauté.
+- **Obtenez des récompenses:** Commencez à gagner en publiant du contenu, en interagissant avec les autres et en participant à l'écosystème.
+- **Restez actif:** Continuez à publier et à interagir pour augmenter vos récompenses et votre visibilité.
+
+Maintenant que vous êtes prêt, rendez-vous sur <a href="https://skatehive.app/" class="button-link" target="_blank">**Webite Skatehive**</a> et commencez à créer!
+
+À bientôt sur la plateforme! 👋

--- a/i18n/fr/docusaurus-plugin-content-docs/current/Level - 2/eth-wallet.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/Level - 2/eth-wallet.md
@@ -1,0 +1,120 @@
+---
+sidebar_position: 1
+---
+
+# Portefeuille Ethereum (Zerion)
+
+### Introduction
+Le **Portefeuille Zerion** est un outil polyvalent conçu pour gérer vos actifs Ethereum et multi-chaînes. Il offre des échanges de tokens sans interruption, prend en charge les solutions de Layer 2 pour des frais de transaction plus bas et propose une interface conviviale. Dans ce guide, nous vous guiderons à travers le processus de création et de configuration de votre **Portefeuille Zerion**.
+
+Bien que d'autres portefeuilles Ethereum comme **MetaMask** et **Trust Wallet** soient également disponibles, Zerion se distingue par son intégration transparente et son support pour plusieurs réseaux blockchain. C'est un excellent choix pour les débutants comme pour les utilisateurs expérimentés.
+
+---
+
+### Installation de l'Extension du Navigateur
+
+# Étape 1 : Visitez <a href="https://zerion.io/download" class="button-link" target="_blank">**Website Zerion.io**</a>
+
+Rendez-vous sur le site de Zerion pour télécharger l'extension du navigateur.
+
+# Étape 2 : Choisissez l'Extension de Votre Navigateur
+Sélectionnez l'extension appropriée pour votre navigateur.
+
+![zerion1](https://hackmd.io/_uploads/BJEu_hgI0.png)
+
+# Étape 3 : Confirmez l'Ajout de l'Extension
+Après avoir choisi l'extension, confirmez son ajout à votre navigateur.
+
+![zerion2](https://hackmd.io/_uploads/B1p1Jpg80.png)
+
+---
+
+### Création d'un Portefeuille
+
+# Étape 1 : Cliquez sur l'Icône de l'Extension du Portefeuille Zerion
+Dans votre navigateur, cliquez sur l'icône de l'extension du Portefeuille Zerion.
+
+# Étape 2 : Cliquez sur **Créer un Nouveau Portefeuille**
+Commencez le processus de création du portefeuille en cliquant sur le bouton **Créer un Nouveau Portefeuille**.
+
+![zerion3](https://hackmd.io/_uploads/HJJ1bpgUR.png)
+
+---
+
+### Configuration du Portefeuille
+
+# Étape 1 : Définissez un PIN ou un Mot de Passe
+**Ce mot de passe déverrouillera le Portefeuille Zerion dans votre navigateur.**
+
+- **Pourquoi ai-je besoin d'un mot de passe ?**
+  - Ce mot de passe est utilisé pour déverrouiller votre portefeuille Zerion lors de la connexion à des applications décentralisées (dApps) ou de la signature de transactions.
+
+![Screenshot from 2024-06-19 17-43-09](https://hackmd.io/_uploads/Hy8bQplUC.png)
+
+# Étape 2 : Confirmez Votre Mot de Passe
+Confirmez votre mot de passe en le saisissant à nouveau.
+
+![Screenshot from 2024-06-19 17-49-23](https://hackmd.io/_uploads/Sk__Epx8R.png)
+
+# Étape 3 : Notez Votre Phrase de Récupération
+**Votre phrase de récupération est le seul moyen d'accéder à vos comptes et actifs**, même si vous oubliez votre mot de passe.
+
+- **Ne partagez jamais votre phrase de récupération ou votre mot de passe avec quiconque**, y compris les membres de l'équipe Zerion.
+
+![zerion4.png](https://hackmd.io/_uploads/rJc9U6gLC.png)
+
+# Étape 4 : Visualisez et Notez Votre Phrase de Récupération
+Cliquez sur l'œil pour révéler votre phrase de récupération et **notez-la sur papier**. Gardez-la en lieu sûr !
+
+![zerion5](https://hackmd.io/_uploads/HJuvhalL0.png)
+
+# Étape 5 : Vérifiez Votre Phrase de Récupération
+Cette étape garantit que vous avez correctement sauvegardé votre phrase de récupération.
+
+![Screenshot from 2024-06-19 18-37-44](https://hackmd.io/_uploads/SJHUXReUR.png)
+
+---
+
+### Épingler l'Extension à Votre Navigateur
+
+Cliquez sur l'icône de l'extension Zerion dans votre navigateur, puis cliquez sur le **bouton d'épingle**.
+
+![zerion6](https://hackmd.io/_uploads/HJ4F4ReUA.png)
+
+---
+
+### Étape 6 : Portefeuille Configuré avec Succès !
+Félicitations, votre portefeuille Zerion est maintenant prêt à l'emploi !
+
+![Screenshot from 2024-06-19 18-39-58](https://hackmd.io/_uploads/HyBoSAgIA.png)
+
+---
+
+### 🛹 Allez sur [skatehive.app](https://www.skatehive.app/) 🛹
+
+# Étape 1 : Modifiez Votre Profil
+Cliquez sur "Modifier le Profil" pour mettre à jour votre compte.
+
+![skthive1](https://hackmd.io/_uploads/B1mnon_IR.png)
+
+# Étape 2 : Ajoutez l'Adresse de Votre Portefeuille Ethereum
+Cliquez sur **Ajouter l'Adresse du Portefeuille Ethereum** et confirmez la transaction dans votre portefeuille Zerion.
+
+![skthive2](https://hackmd.io/_uploads/HyrJbkK8R.png)
+
+# Étape 3 : Confirmez l'Adresse de Votre Portefeuille
+Vérifiez l'adresse de votre portefeuille et cliquez sur **Confirmer l'Adresse**.
+
+![skthive3](https://hackmd.io/_uploads/HkBLWJY8R.png)
+
+# Étape 4 : Enregistrez les Modifications
+Une fois que vous avez confirmé l'adresse de votre portefeuille, cliquez sur **Enregistrer les Modifications**.
+
+![skthive4](https://hackmd.io/_uploads/rkH1Q1tIA.png)
+
+---
+
+### Vous êtes Prêt ! 🎉
+Vous êtes maintenant prêt à recevoir des récompenses sur Skatehive !
+
+![nounsequiperocket](https://hackmd.io/_uploads/B1kSOkGIC.gif)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/Level - 2/hive-witness.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/Level - 2/hive-witness.md
@@ -1,0 +1,59 @@
+---
+title: Hive Witness
+sidebar_position: 9
+---
+
+# Comment voter pour le témoin Skatehive sur la blockchain Hive
+
+La blockchain Hive est une plateforme décentralisée qui fonctionne avec des témoins pour maintenir le réseau sécurisé et fonctionnel. Voter pour un témoin, comme Skatehive, aide à soutenir les initiatives qui promeuvent la culture du skateboard et la décentralisation. Ce tutoriel vous guidera à travers le processus.
+
+---
+
+#### Étape 1 : Connectez-vous à un client Hive
+**Pour voter, vous aurez besoin d'un client Hive, tel que :**
+- **Hive Keychain** : Une extension de navigateur pour gérer les comptes.
+- **Ecency** : Une plateforme conviviale pour interagir avec Hive.
+- **PeakD** : Une interface avancée pour les utilisateurs de Hive.
+
+Téléchargez et installez l'extension Hive Keychain (si ce n'est pas déjà fait) et connectez-vous avec vos identifiants.
+
+---
+
+#### Étape 2 : Accédez à la page de vote des témoins
+1. Allez sur [PeakD](https://peakd.com) ou [Hive Blog](https://hive.blog).
+2. Cliquez sur le menu ou recherchez l'option "Témoins".
+   - Sur PeakD, c'est dans la barre latérale gauche.
+   - Sur Hive Blog, vous pouvez accéder directement au lien : [https://hive.blog/~witnesses](https://hive.blog/~witnesses).
+
+![](https://i.ibb.co/ZhFv3bY/image.png)
+---
+
+#### Étape 3 : Trouvez le témoin Skatehive
+1. Dans la liste des témoins, recherchez **Skatehive**.
+   - Utilisez la barre de recherche (Ctrl + F sur votre clavier) et tapez "skatehive".
+2. Si vous ne le trouvez pas, utilisez le lien direct pour voter : [https://peakd.com/me/witnesses](https://peakd.com/me/witnesses) et ajoutez manuellement le nom du témoin `skatehive`.
+![](https://i.ibb.co/M7frCxC/image.png)
+
+---
+
+#### Étape 4 : Votez pour Skatehive
+1. Cliquez sur le bouton de vote à côté du nom Skatehive.
+2. Confirmez votre action :
+   - Si vous utilisez Hive Keychain, il vous demandera d'autoriser la transaction.
+   - Confirmez et entrez votre clé d'accès (si nécessaire).
+
+---
+
+#### Étape 5 : Vérifiez votre vote
+**Après avoir voté :**
+1. Vérifiez que Skatehive apparaît dans votre liste de votes actifs.
+2. Vous pouvez le faire sur la même page des témoins ou dans l'onglet des paramètres de votre compte.
+
+---
+
+### Conseils finaux
+- **Pourquoi voter pour Skatehive ?** Skatehive est un témoin qui promeut la communauté du skateboard sur la blockchain Hive, favorisant la décentralisation et la créativité.
+- **Limite de votes** : Chaque compte peut voter pour jusqu'à 30 témoins. Utilisez vos votes judicieusement.
+- **Impliquez-vous** : Rejoignez la communauté Skatehive et aidez à renforcer le projet.
+
+Maintenant que vous savez comment voter, soutenez Skatehive et faites partie de cette incroyable communauté ! 🛹

--- a/i18n/fr/docusaurus-plugin-content-docs/current/create-account.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/create-account.mdx
@@ -1,0 +1,154 @@
+---
+position: 1
+title: Créer un compte
+---
+# Comment créer un compte Skatehive
+
+
+<div style={{
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  margin: '20px 0'
+}}>
+<video width="600" controls>
+  <source src="https://ipfs.skatehive.app/ipfs/QmYuM1h51bddDuC44FoAQYp9FRF2CghCncULeS4T3bp727" type="video/mp4" />
+  Votre navigateur ne supporte pas la balise vidéo.
+</video>
+</div>
+
+## 1. Référez un ami à Skatehive en utilisant votre compte
+
+1. **Naviguez jusqu'à l'icône du robot** en haut de Skatehive ou [cliquez ici](https://www.skatehive.app/invite).  
+
+<img src="https://i.ibb.co/JCCj9Sf/image.png" alt="Naviguez jusqu'à l'icône du robot" width="150" />
+
+2. **Choisissez leur nom d'utilisateur**. Assurez-vous qu'ils l'aiment, car il ne peut pas être facilement changé. Tapez leur adresse e-mail.  
+![Entrez le nom d'utilisateur et l'e-mail](https://hackmd.io/_uploads/H1tZGNP1Jx.png)
+
+3. Une fois que vous cliquez sur **"Ça a l'air bien, allez-y"**, une transaction Keychain sera demandée. Après approbation, le compte sera créé et votre ami recevra un e-mail.
+
+---
+
+## Recevez une invitation par e-mail
+
+Votre ami recevra un e-mail contenant ses **CLÉS HIVE**.  
+![E-mail des clés Hive](https://ipfs.skatehive.app/ipfs/QmbTbULhRtAfyd19cTNYfrsjpsuRN2TV9sxZ5yzQQeR44D)
+
+### Important : Gardez vos clés en sécurité
+- **Ne perdez jamais vos clés !** Elles ne peuvent pas être récupérées si elles sont perdues.
+- Skatehive.app ne stocke pas de copies de vos clés pour des raisons de sécurité. Il est de votre responsabilité de les stocker en toute sécurité.
+
+### Connexion
+Utilisez votre nom d'utilisateur et votre mot de passe pour vous connecter à Skatehive via n'importe quel navigateur. Cependant, nous recommandons d'utiliser **Hive Keychain** pour une expérience la plus sécurisée.
+
+#### Options Hive Keychain pour mobile
+
+<div style={{ display: 'flex', justifyContent: 'center' }}>
+
+
+| iOS  | Android |
+| -------- | -------- |
+| ![](https://hive-keychain.com/img/browsers/ios.svg) | ![](https://hive-keychain.com/img/browsers/android.svg) |  
+
+</div>
+
+#### Options Hive Keychain pour bureau
+
+<div style={{
+  display: 'flex', 
+  justifyContent: 'center', 
+  backgroundColor: 'var(--ifm-color-background)', 
+  padding: '20px', 
+  borderRadius: '8px',
+  color: 'var(--text-color)'
+}}>
+  <table style={{
+    textAlign: 'center', 
+    borderSpacing: '16px', 
+    color: 'inherit'
+  }}>
+    <thead>
+      <tr>
+        <th style={{ color: 'inherit' }}>Chrome</th>
+        <th style={{ color: 'inherit' }}>Brave</th>
+        <th style={{ color: 'inherit' }}>Firefox</th>
+      </tr>
+    </thead>
+    <tbody style={{ backgroundColor: '#808080'}}>
+      <tr>
+        <td style={{
+          padding: '10px', 
+          borderRadius: '8px',
+          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)'
+        }}>
+          <img 
+            src="https://hive-keychain.com/img/browsers/chrome.svg" 
+            alt="Chrome" 
+            style={{
+              maxWidth: '60px',
+              borderRadius: '8px'
+            }}
+          />
+        </td>
+        <td style={{
+          padding: '10px', 
+          borderRadius: '8px',
+          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)'
+        }}>
+          <img 
+            src="https://hive-keychain.com/img/browsers/brave.svg" 
+            alt="Brave" 
+            style={{
+              maxWidth: '60px',
+              borderRadius: '8px'
+            }}
+          />
+        </td>
+        <td style={{
+          padding: '10px', 
+          borderRadius: '8px',
+          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)'
+        }}>
+          <img 
+            src="https://hive-keychain.com/img/browsers/firefox.svg" 
+            alt="Firefox" 
+            style={{
+              maxWidth: '60px',
+              borderRadius: '8px'
+            }}
+          />
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+---
+
+## 2. Configuration de Hive Keychain
+
+**Hive Keychain** stocke en toute sécurité vos informations de clé privée. Il est disponible en tant qu'extension de navigateur pour bureau et en tant qu'application mobile (qui sert également de navigateur web). Utilisez-le pour vous connecter aux frontends Hive, y compris Skatehive.
+
+### Pour les utilisateurs mobiles
+1. Créez un code PIN pour déverrouiller le keychain.
+   ![Définir le code PIN](https://hackmd.io/_uploads/rk9Y1SDJJg.png)
+
+2. Après avoir configuré le code PIN, cliquez sur **Utiliser les clés/mot de passe** et entrez votre **mot de passe principal**.  
+   ![Entrez le mot de passe principal](https://hackmd.io/_uploads/HyBYyBwJJg.png)
+
+3. Connectez-vous à Skatehive en entrant votre **nom d'utilisateur**.  
+   ![Connexion à Skatehive](https://hackmd.io/_uploads/ByGmlHDkJl.png)
+
+Une fois que Hive Keychain approuve la transaction, vous serez connecté.
+
+---
+
+## 3. Créez un compte Hive vous-même
+
+Vous pouvez également créer des comptes Hive (portefeuilles) en utilisant d'autres frontends Hive, puis utiliser ces comptes pour vous connecter à Skatehive.
+
+### Étapes :
+1. Assurez-vous d'avoir **Hive Keychain** installé.
+2. Allez sur [HiveOnboard](https://hiveonboard.com/create-account) et créez votre compte.
+

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/Level - 0/fork-skatehive.md
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/Level - 0/fork-skatehive.md
@@ -1,48 +1,50 @@
 ---
-title:  Como fazer um fork da Skatehive
+title: Fork Skatehive Guide
 sidebar_position: 1
 ---
 
 # Como fazer um fork da Skatehive 🛹
 
-Faremos este tutorial para qualquer pessoa que queira criar sua própria comunidade com a tecnologia da skatehive, como https://skatehive.app
+Faremos este tutorial para qualquer pessoa que queira criar sua própria comunidade com a tecnologia da skatehive, como <a href="https://skatehive.app" class="button-link" target="_blank">**Skatehive.app**</a>.
 
 Você precisará instalar algumas coisas em sua máquina para preparar seu computador para o desenvolvimento do fork.
 
 O código ainda está um pouco confuso, mas convido você a fazer parte do nosso aprendizado. Este documento será sempre atualizado em: https://docs.skatehive.app
 
-### Index
+## Índice
 
 - Instale o Git e configure a conta do Github
 - Configure suas keys SSH do Github
-- Fork o repositorio
-- Clone/Download o repositorio
-- Faça o Dowload e instale o Node.js
-- Instale o pnpm
-- Instale as dependencias com o comando `pnpm`
-- Mude as variaveis .env
-- Execute com o comando `pnpm dev`
+- Fork o repositório 
+- Clone/Download o repositório
+- Faça o Download e instale o NodeJs
+- Instale o pnpm 
+- Instale as dependências com `pnpm`
+- Mude as variáveis .env
+- Execute com `pnpm dev`
 - Fiz algumas modificações apenas por diversão
-- Envie suas alterações para o github
--  Coloque seu fork online, faça deploy com o vercel
+- Envie suas alterações para o github 
+- Coloque seu fork online, faça deploy com o vercel 
 
 
-### Instale o Git e configure a conta do Github
+## Instale o Git e configure a conta do Github
 
-Baixe e instale o Git em sua máquina local. Isso permitirá que você execute comandos git em seu terminal, como `git clone` e outros comandos
+Baixe e instale o Git em sua máquina local. Isso permitirá que você execute comandos git em seu terminal, como `git clone` e outros comandos mágicos 
+
 
 [Download Git](https://git-scm.com/downloads)
 [Learn More about git and its instalation](https://www.youtube.com/results?search_query=what+is+git+how+to+install)
 
-### Crie sua conta no GitHub
+## Crie sua conta no GitHub
 
-Basta se inscrever
+Basta se inscrever 
 
-### Configure suas chaves (Keys) SSH do Github
+## Configure suas chaves (Keys) SSH do Github 
 
-Para tornar o processo mais tranquilo, vamos configurar uma conexão SSH gerando chaves SSH.
+Para tornar o processo mais tranquilo, vamos configurar uma conexão SSH gerando chaves SSH. 
 
-1. Abra seu terminal
+
+1. Abra seu terminal 
 
 2. Digite o seguinte comando
 > use o mesmo e-mail que você usou para criar a conta no github
@@ -53,46 +55,48 @@ ssh-keygen -t ed25519 -C "your_email@example.com"
 > Isso cria uma nova chave SSH, usando o e-mail fornecido como rótulo.
 
 3. Inicie o agente ssh em segundo plano
+
 ```
 eval "$(ssh-agent -s)"
 ```
 
 4. Copie o conteúdo do arquivo id_ed25519.pub para sua área de transferência
-- Para usuarios do Mac: 
+
+- Para usuários do Mac: 
 `pbcopy < ~/.ssh/id_ed25519.pub`
 
-- Para usuarios do Windows: 
+- Para usuários do Windows: 
 `clip < ~/.ssh/id_ed25519.pub`
 
 
 
  Dê um título e cole o conteúdo em Key
-![Alt ​​text](../../../../../src/assets/Tuto-Dev/1.png)
+![Alt ​​text](../../src/assets/Tuto-Dev/1.png)
 
 
 
 > [Full SSH Tutorial](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
 
-### Fork o repositorio
+## Fork o repositório
 
- **[Click Fork Button](https://github.com/sktbrd/skateapp)** 
+ **[Click Fork Button](https://github.com/SkateHive/nextskateapp)** 
 
-![Alt ​​text](../../../../../src/assets/Tuto-Dev/2.png)
+![Alt ​​text](../../src/assets/Tuto-Dev/2.png)
 
-Isso criará sua própria versão do repositório em sua conta:
+Isso criará sua própria versão do repositório em sua conta: 
 
-![Alt ​​text](../../../../../src/assets/Tuto-Dev/3.png)
+![Alt ​​text](../../src/assets/Tuto-Dev/3.png)
 
-Pronto, agora você vai clonar o repositório de arquivos na sua máquina, que é basicamente baixar o app:
+Pronto, agora você vai clonar o repositório de arquivos na sua máquina, que é basicamente baixar o app: 
 
 ```
 git clone git@github.com:<your-username>/<your-fork>.git
 ```
 
-![Alt ​​text](../../../../../src/assets/Tuto-Dev/4.png)
+![Alt ​​text](../../src/assets/Tuto-Dev/4.png)
 
 
-Agora navegue até o repositório clonado por:
+Agora navegue até o repositório clonado por: 
 
 ```
 cd <your-fork>
@@ -101,45 +105,52 @@ cd <your-fork>
 Nesse caso, 
 
 ```
-cd skateapp
+cd nextskateapp
 ``` 
 
-Para a próxima etapa precisaremos instalar mais alguns programas em seu computador para completar seu ambiente e finalmente instalar e executar o aplicativo.
+Para a próxima etapa precisaremos instalar mais alguns programas em seu computador para completar seu ambiente e finalmente instalar e executar o aplicativo. 
+
 
 ## [Download and install Node.Js](https://nodejs.org/en)
 
 > Nada sofisticado aqui, basta instalar e deixar o `add to path` marcado.
 
-### [Install Yarn Here](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable)
+## [Instale o pnpm Aqui](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) ou 
+
+```
+npm install -g pnpm
+```
 
 > [More ways to install Yarn](https://www.youtube.com/results?search_query=install+yarn)
 
 
-Se você possui Nodejs, npm, yarn e weed/coffee agora você pode instalar e executá-lo em seu computado.
+Se você possui Nodejs, npm, yarn e weed/coffee agora você pode instalar e executá-lo em seu computado. 
 
-### Voltando ao terminal... 
+## Voltando ao terminal... 
 
 Na pasta do repositório
+
 ```
-yarn
+pnpm i
 ```
 > Nota: Este comando instalará automaticamente todos os pacotes JavaScript e dependências necessários para o seu projeto, conforme especificado no arquivo package.json. O Yarn irá baixar e configurar tudo o que for necessário para executar a Skatehive.
 Esta etapa garante que você tenha todas as bibliotecas e ferramentas necessárias em seu computador para construir e executar o aplicativo.
 
-![Alt ​​text](../../../../../src/assets/Tuto-Dev/5.png)
+
+![Alt ​​text](../../src/assets/Tuto-Dev/5.png)
 Espere um pouco, tome um "café"...
 
-Você deverá ver isso quando acabar:
-![Alt ​​text](../../../../../src/assets/Tuto-Dev/6.png)
+Você deverá ver isso quando acabar: 
+![Alt ​​text](../../src/assets/Tuto-Dev/6.png)
 
-> Se você receber um erro em alguma etapa, você pode jogá-lo no chat-gpt ou perguntar-nos em [skatehive discord](https://discord.gg/skatehive) e ver qual deles ajuda você mais rápido
+> Se você receber um erro em alguma etapa, você pode jogá-lo no chat-gpt ou perguntar-nos em [skatehive discord](https://discord.gg/skatehive) e ver qual deles ajuda você mais rápido 
 
 
-### Renomeie .env.example para .env 
+## Renomeie .env.example para .env 
 
-Renomeie .env.example e escolha a comunidade Hive da qual deseja obter/carregar conteúdo. Por exemplo, se você usar o hive-173115 você obterá o skatehive, se você usar o hive-141964 no campo comunitário você obterá o surfhive
+Renomeie .env.example e escolha a comunidade Hive da qual deseja obter/carregar conteúdo. Por exemplo, se você usar o hive-173115 você obterá o skatehive, se você usar o hive-141964 no campo comunitário você obterá o surfhive 
 
-### .env.example
+## .env.example
 NEXT_PUBLIC_WEBSITE_URL=http://localhost:3000/
 NEXT_PUBLIC_HIVE_COMMUNITY_TAG=xxxxxxxxxxx
 NEXT_PUBLIC_PINATA_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
@@ -149,34 +160,44 @@ NEXT_PUBLIC_CRYPTO_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 NEXT_PUBLIC_OPENAI_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 NEXT_PUBLIC_ETHERSCAN_API=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+Agora execute o aplicativo que você acabou de instalar: 
 
-
-Agora execute o aplicativo que você acabou de instalar:
 ```
 pnpm dev
 ```
-![Alt ​​text](../../../../../src/assets/Tuto-Dev/7.png)
+![Alt ​​text](../../src/assets/Tuto-Dev/7.png)
 
 
-Agora abra https://localhost:5173 e você verá o mesmo aplicativo que https://skatehive.app
+Agora abra https://localhost:3000 <a href="https://skatehive.app" class="button-link" target="_blank"></a> e você verá o mesmo aplicativo que <a href="https://skatehive.app" class="button-link" target="_blank">**Website Skatehive**</a>.
 
-![Alt ​​text](../../../../../src/assets/Tuto-Dev/8.png)
+![Alt ​​text](../../src/assets/Tuto-Dev/8.png)
 
-Isso significa que você está executando o aplicativo usando seu próprio computador como servidor através da porta 5173
+Isso significa que você está executando o aplicativo usando seu próprio computador como servidor através da porta 3000 
 
-Agora você pode tentar editar seu código em um editor de código, eu recomendo [VSCode](https://code.visualstudio.com/), mas meu Mestre Jedi recomenda [JetBrains](https://www.jetbrains.com/ )
+Agora você pode tentar editar seu código em um editor de código, eu recomendo <a href="https://code.visualstudio.com/" class="button-link" target="_blank">**Website VSCode**</a>, mas meu Mestre Jedi recomenda <a href="https://www.jetbrains.com/" class="button-link" target="_blank">**Website JetBrains**</a>.
 
-Eu costumo usar o comando `code.` na pasta do terminal para abrir facilmente a pasta em que estamos trabalhando no VScode
+
+Eu costumo usar o comando `code .` na pasta do terminal para abrir facilmente a pasta em que estamos trabalhando no VScode
 
 Faça uma mudança boba, como mudar o rodapé.
 
-![Alt ​​text](../../../../../src/assets/Tuto-Dev/9.png)
+![Alt ​​text](../../src/assets/Tuto-Dev/9.png)
 
 
-Este projeto é construído com TypeScript e incorpora Chakra UI para o frontend. Para tarefas relacionadas ao Hive, contamos com o [Keychain SDK](https://play.hive-keychain.com/) e as bibliotecas dive. Além disso, para facilitar as interações com Ethereum, Bitcoin e vários outros blockchains, aproveitamos os recursos do [Pioneer-React](https://github.com/BitHighlander/pioneer-react#readme).
+Este projeto é construído com TypeScript e incorpora Chakra UI para o frontend. Para tarefas relacionadas ao Hive, contamos com o <a href="https://play.hive-keychain.com/" class="button-link" target="_blank">**Website Keychain SDK**</a> e as bibliotecas dive. Além disso, para facilitar as interações com Ethereum, Bitcoin e vários outros blockchains, aproveitamos os recursos do <a href="https://github.com/BitHighlander/pioneer-react#readme" class="button-link" target="_blank">**WebSite Pioneer-React**</a>.
+
 
 
 **Stage Changes:**
+
+Antes de enviar para o github é bom: 
+
+```
+pnpm build:turbo 
+```
+
+e testar sua build localmente!
+
 ```
 git add .
 ````
@@ -187,39 +208,40 @@ git add .
 ```
 git commit -m "Changed header color".
 ```
-> Commit com uma mensagem
+> Commit com uma mensagem 
 
 **Push to GitHub:**
 ```
 git push origin main
 ```
-> Envie suas mudanças
+> Envie suas mudanças 
 
-Agora você pode acessar sua conta do github e verificar se ela foi atualizada
+Agora você pode acessar sua conta do github e verificar se ela foi atualizada 
 
-### Colocando seu website online
+## Colocando seu website online 
 
-###  Va para  vercel.com 
+## Vá para vercel.com 
 
 1. Faça uma conta com sua conta do github 
-![Alt ​​text](../../../../../src/assets/Tuto-Dev/10.png)
+![Alt ​​text](../../src/assets/Tuto-Dev/10.png)
 
-2.Instale a extensão Github 
-3. Selecione o repositório
-![Alt ​​text](../../../../../src/assets/Tuto-Dev/11.png)
+2. Instale a extensão Github que ele oferece 
+3. Selecione o repositório 
+![Alt ​​text](../../src/assets/Tuto-Dev/11.png)
 
 4. Clique em Deploy
 
-Você deverá ver algo assim:
+Você deverá ver algo assim: 
 
-![Alt ​​text](../../../../../src/assets/Tuto-Dev/12.png)
+![Alt ​​text](../../src/assets/Tuto-Dev/12.png)
  
 
-Você pode navegar agora para:
+Você pode navegar agora para: 
 
 https://your-repo.vercel.app 
 
- Veja sua própria comunidade Hive.
+e ver sua própria comunidade Hive. 
 
-Parabéns! Que legal, você colocou um site  online! Vá mostrar para sua mãe, diga que estou com saudades dela.
+Parabéns! Que legal, você colocou um site online! Vá mostrar para sua mãe, diga que estou com saudades dela. 
+
 --- 

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/Level - 1/hive-wallet.md
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/Level - 1/hive-wallet.md
@@ -7,13 +7,18 @@ sidebar_position: 2
 ### **1. Instale o Hive Keychain**  
 - **No Chrome:** Vá até a [Chrome Web Store](https://chrome.google.com/webstore) e pesquise por "Hive Keychain". Clique em **"Adicionar ao Chrome"**.  
 - **No Firefox:** Baixe pelo site oficial do [Hive Keychain](https://hive-keychain.com).  
+![alt text](image.png)
 
 ### **2. Configure a Carteira**  
 - Após instalar, clique no ícone do Hive Keychain no navegador.  
 - Crie uma senha para proteger sua carteira.  
 
+![Image](https://ipfs.skatehive.app/ipfs/QmVavmvptLv455oWxdxnuunnoyiMsZU4M66BPSoNBL8rKv)
+
 ### **3. Adicione sua Conta Hive**  
-- Clique em **"Import Account"**.  
+- Clique em **"Use Keys"**.  
+![Image](https://ipfs.skatehive.app/ipfs/QmY6ePRFSBL2ZzN17p23sBPKt197BNtEk5K3kqa8VTdBb2)  
+
 - Digite seu nome de usuário da Hive.  
 - Cole sua chave privada (recomenda-se a "Active Key" para transações e a "Posting Key" para interações).  
 
@@ -27,4 +32,4 @@ sidebar_position: 2
 🔹 Guarde suas chaves em um local seguro.  
 🔹 Sempre baixe o Hive Keychain de fontes oficiais.  
 
-Agora você pode usar a Hive com mais praticidade! 🚀
+Agora você pode usar a Hive com mais praticidade! ehehe 🚀 

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/Level - 1/nftskatehive.md
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/Level - 1/nftskatehive.md
@@ -4,77 +4,72 @@ sidebar_position: 6
 ---
 
 
-O leilão de NFTs da Skatehive, construído com o NounsBuilder, é um mecanismo que permite a criação, leilão e distribuição de NFTs de forma descentralizada e comunitária. Abaixo está um resumo de como o processo funciona:
+### **1. O que é o NounsBuilder?**  
+NounsBuilder é uma ferramenta que permite a criação de projetos inspirados no modelo dos **Nouns**, um projeto de NFT conhecido por sua abordagem de leilão contínuo e governança comunitária. Ele fornece uma estrutura modular para criar NFTs com características únicas e leilões periódicos.  
 
 ---
 
-### **1. O que é o NounsBuilder?**
-O NounsBuilder é uma ferramenta que permite a criação de projetos inspirados no modelo dos **Nouns**, um projeto de NFT conhecido por sua abordagem de leilões contínuos e governança comunitária. Ele oferece uma estrutura modular para criar NFTs com características únicas e leilões periódicos.
+### **2. Como Funciona o Leilão de NFTs da Skatehive?**  
+O leilão da Skatehive segue um modelo semelhante ao dos Nouns, com adaptações específicas para a comunidade de skate. Aqui estão os principais aspectos:  
+
+#### **a) Criação de NFTs**  
+- Cada NFT é gerado programaticamente combinando diferentes características armazenadas em um repositório on-chain.  
+
+![Image](https://ipfs.skatehive.app/ipfs/Qmc7U3gvJmnVx99PPBA9dz3NZwx5pLsE6viwqiJttHiGSg)  
+
+- Essas características podem incluir designs de skates, shapes, rodas, grafites ou outros elementos visuais relacionados ao skate.  
+- O processo de criação é totalmente autônomo através de um contrato inteligente, garantindo que cada NFT seja único.  
+
+#### **b) Leilões Contínuos**  
+- Os NFTs são leiloados em um processo contínuo, com um novo leilão começando imediatamente após o término do anterior.  
+- Cada leilão tem uma duração fixa (por exemplo, 24 horas).  
+- Os participantes fazem lances em criptomoedas (como ETH) para adquirir o NFT.  
+
+#### **c) Distribuição de Fundos**  
+- Os fundos arrecadados através dos leilões são distribuídos de acordo com as regras do contrato inteligente:  
+  - Atualmente, todos os recursos vão para o **Tesouro da Comunidade**, que pode ser usado para financiar projetos, eventos ou iniciativas relacionadas ao skate.  
+
+#### **d) Governança Descentralizada**  
+- Os detentores de NFTs da Skatehive têm direitos de governança, permitindo que participem das decisões sobre o futuro do projeto.  
+- Por exemplo, eles podem votar em propostas para alocar fundos do tesouro ou adicionar novas características aos NFTs.  
+
+![Image](https://ipfs.skatehive.app/ipfs/Qme3d63w91sR6uMGCbJSdjQU3sKhNJ9gYj9fwP1WUAZGto)  
 
 ---
 
-### **2. Como funciona o leilão de NFTs da Skatehive?**
-O leilão da Skatehive segue um modelo semelhante ao dos Nouns, com algumas adaptações específicas para a comunidade do skate. Aqui estão os principais pontos:
-
-
-#### **a) Criação de NFTs**
-- Cada NFT é gerado de forma programática, combinando diferentes características (traços) que são armazenadas em um repositório on-chain.
-
-![Image](https://ipfs.skatehive.app/ipfs/Qmc7U3gvJmnVx99PPBA9dz3NZwx5pLsE6viwqiJttHiGSg)
-
-- Esses traços podem incluir designs de skates, shapes, rodas, grafites, ou outros elementos visuais relacionados ao skate.
-- A criação é feita de forma autônoma pelo contrato inteligente, garantindo que cada NFT seja único.
-
-#### **b) Leilões Contínuos**
-- Os NFTs são leiloados em um processo contínuo, com um novo leilão começando imediatamente após o término do anterior.
-- Cada leilão tem uma duração fixa (por exemplo, 24 horas).
-- Os participantes fazem lances em criptomoedas (como ETH) para adquirir o NFT.
-
-#### **c) Distribuição de Fundos**
-- Os fundos arrecadados nos leilões são distribuídos de acordo com as regras definidas pelo contrato inteligente:
-  - Atualmente todos os fundos arrecadados vão para o **Tesouro da Comunidade**, que pode ser usado para financiar projetos, eventos ou iniciativas relacionadas ao skate.
-  
-#### **d) Governança Descentralizada**
-- Os detentores dos NFTs da Skatehive têm direitos de governança, permitindo que participem de decisões sobre o futuro do projeto.
-- Por exemplo, eles podem votar em propostas para usar os fundos do tesouro ou para adicionar novos traços aos NFTs.
-
-
-![Image](https://ipfs.skatehive.app/ipfs/Qme3d63w91sR6uMGCbJSdjQU3sKhNJ9gYj9fwP1WUAZGto)
----
-
-####  **3. Participação no Leilão**
-Para participar do leilão, os usuários precisam:
-1. Conectar sua carteira de criptomoedas (como MetaMask) à plataforma da Skatehive.
-2. Fazer lances durante o período do leilão.
-3. Se forem o maior lance ao final do leilão, recebem o NFT em sua carteira.
+### **3. Participando do Leilão**  
+Para participar do leilão, os usuários devem:  
+1. Conectar sua carteira de criptomoedas (como MetaMask) à plataforma Skatehive.  
+2. Fazer lances durante o período do leilão.  
+3. Se tiverem o maior lance ao final do leilão, receberão o NFT em sua carteira.  
 
 ---
 
-#### **4. Benefícios dos NFTs da Skatehive**
-- **Exclusividade**: Cada NFT é único e pode se valorizar com o tempo.
-- **Comunidade**: Os detentores fazem parte de uma comunidade engajada e têm voz ativa nas decisões.
-- **Apoio ao Skate**: Parte dos fundos é reinvestida em iniciativas relacionadas ao skate, promovendo a cultura e o esporte.
+### **4. Benefícios dos NFTs da Skatehive**  
+- **Exclusividade**: Cada NFT é único e pode valorizar ao longo do tempo.  
+- **Comunidade**: Os detentores tornam-se parte de uma comunidade engajada e têm voz nas decisões.  
+- **Apoio ao Skate**: Parte dos fundos é reinvestida em iniciativas de skate, promovendo a cultura e o esporte.  
 
 ---
 
-#### **5. Tecnologia por Trás**
-- **Contratos Inteligentes**: Toda a lógica de criação, leilão e distribuição é executada por contratos inteligentes na blockchain (geralmente Ethereum ou uma L2 como Base).
-- **Transparência**: Todas as transações e regras são públicas e verificáveis na blockchain.
-- **Interoperabilidade**: Os NFTs podem ser negociados em marketplaces como OpenSea ou Blur.
+### **5. Tecnologia Subjacente**  
+- **Contratos Inteligentes**: Toda a lógica de criação, leilão e distribuição é executada via contratos inteligentes na blockchain (geralmente Ethereum ou uma Layer 2 como Base).  
+- **Transparência**: Todas as transações e regras são públicas e verificáveis na blockchain.  
+- **Interoperabilidade**: Os NFTs podem ser negociados em marketplaces como OpenSea ou Blur.  
 
 ---
 
-#### **6. Exemplo de Fluxo**
-1. Um novo NFT é gerado com traços únicos.
-2. O leilão começa e dura 24 horas.
-3. Os usuários fazem lances.
-4. Ao final, o maior lance vence e o NFT é transferido para o vencedor.
-5. Os fundos são distribuídos conforme as regras do contrato.
-6. Um novo leilão começa imediatamente
+### **6. Fluxo de Exemplo**  
+1. Um novo NFT é gerado com características únicas.  
+2. O leilão começa e dura 24 horas.  
+3. Os usuários fazem lances.  
+4. No final do leilão, o maior lance vence e o NFT é transferido para a carteira do vencedor.  
+5. Os fundos são distribuídos de acordo com as regras do contrato inteligente.  
+6. Um novo leilão começa imediatamente.  
 
 ---
 
-#### **7. Considerações Finais**
-O leilão de NFTs da Skatehive no NounsBuilder é uma forma inovadora de engajar a comunidade do skate, gerar valor para os participantes e financiar iniciativas relevantes. A transparência e a descentralização garantem que todos os envolvidos tenham voz e benefícios justos.
+### **7. Considerações Finais**  
+O leilão de NFTs da Skatehive no NounsBuilder é uma maneira inovadora de engajar a comunidade de skate, criar valor para os participantes e financiar iniciativas significativas. A transparência e a descentralização garantem que todos os envolvidos tenham voz e recebam benefícios justos.  
 
-Se precisar de mais detalhes técnicos ou exemplos específicos, é só avisar! 🛹
+Se precisar de mais detalhes técnicos ou exemplos específicos, é só avisar! 🛹  

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/Level - 1/telainicial.md
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/Level - 1/telainicial.md
@@ -26,3 +26,5 @@ Seu navegador pode pedir para você escolher um nome para o atalho. Você pode m
 Pronto! Agora o Skatehive estará na tela inicial do seu celular como um ícone, tornando o acesso muito mais rápido e prático. 🛹🔥  
 
 ---  
+
+Deixe-me saber se você precisa de alguma alteração ou melhoria! 😊

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/Level - 2/hive-witness.md
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/Level - 2/hive-witness.md
@@ -1,6 +1,6 @@
 ---
 title: Hive Witness
-sidebar_position: 4
+sidebar_position: 9
 ---
 
 # Como Votar no Skatehive Witness na Hive Blockchain
@@ -9,25 +9,17 @@ A Hive Blockchain é uma plataforma descentralizada que opera com testemunhas (w
 
 ---
 
-#### Passo 1: Crie uma Conta na Hive (se necessário)
-Se você ainda não tem uma conta na Hive, siga estas etapas:
-1. Acesse [hive.io](https://hive.io) e clique em "Get Started".
-2. Escolha uma das opções de criação de conta (Hive Keychain, Ecency, ou outros provedores).
-3. Guarde suas chaves de acesso em um local seguro. **Elas são essenciais para acessar sua conta.**
-
----
-
-#### Passo 2: Faça Login em um Cliente Hive
-Para votar, você precisará de um cliente Hive, como:
-- **Hive Keychain**: Extensão para navegadores que facilita o gerenciamento de contas.
-- **Ecency**: Plataforma amigável para interagir com a Hive.
+#### Passo 1: Faça Login em um Cliente Hive
+**Para votar, você precisará de um cliente Hive, como:**
+- **Hive Keychain**: Uma extensão de navegador para gerenciar contas.
+- **Ecency**: Uma plataforma amigável para interagir com a Hive.
 - **PeakD**: Uma interface avançada para usuários da Hive.
 
 Baixe e instale a extensão Hive Keychain (se ainda não tiver) e faça login com suas credenciais.
 
 ---
 
-#### Passo 3: Acesse a Página de Votação de Witnesses
+#### Passo 2: Acesse a Página de Votação de Witnesses
 1. Entre em [PeakD](https://peakd.com) ou [Hive Blog](https://hive.blog).
 2. Clique no menu ou procure a opção "Witnesses".
    - No PeakD, está no menu lateral esquerdo.
@@ -36,15 +28,15 @@ Baixe e instale a extensão Hive Keychain (se ainda não tiver) e faça login co
 ![](https://i.ibb.co/ZhFv3bY/image.png)
 ---
 
-#### Passo 4: Localize o Skatehive Witness
+#### Passo 3: Localize o Skatehive Witness
 1. Na lista de witnesses, procure por **Skatehive**.
    - Use o campo de busca (Ctrl + F no teclado) e digite "skatehive".
 2. Se não encontrar, use o link direto para votar: [https://peakd.com/me/witnesses](https://peakd.com/me/witnesses) e adicione manualmente o nome do witness `skatehive`.
-
 ![](https://i.ibb.co/M7frCxC/image.png)
+
 ---
 
-#### Passo 5: Vote no Skatehive
+#### Passo 4: Vote no Skatehive
 1. Clique no botão de votação ao lado do nome do Skatehive.
 2. Confirme sua ação:
    - Se estiver usando o Hive Keychain, ele solicitará que você autorize a transação.
@@ -52,8 +44,8 @@ Baixe e instale a extensão Hive Keychain (se ainda não tiver) e faça login co
 
 ---
 
-#### Passo 6: Verifique Seu Voto
-Após votar:
+#### Passo 5: Verifique Seu Voto
+**Após votar:**
 1. Confirme que o Skatehive aparece na lista dos seus votos ativos.
 2. Isso pode ser feito na mesma página de witnesses ou na aba de configurações da sua conta.
 

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/create-account.mdx
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/create-account.mdx
@@ -1,9 +1,9 @@
 ---
-posição: 1
-título: Crie como uma conta Hive
+position: 1
+title: Criar Conta
 ---
+# Como Criar uma Conta Skatehive
 
-# Como criar uma conta Skatehive
 
 <div style={{
   display: 'flex',
@@ -12,44 +12,48 @@ título: Crie como uma conta Hive
   margin: '20px 0'
 }}>
 <video width="600" controls>
-  <source src="https://ipfs.skatehive.app/ipfs/QmeBM4tGTwh4QZ8wSozY8oF7mmGDSXfHgWg7qehmhYAWvE" type="video/mp4" />
+  <source src="https://ipfs.skatehive.app/ipfs/QmYuM1h51bddDuC44FoAQYp9FRF2CghCncULeS4T3bp727" type="video/mp4" />
   Seu navegador não suporta a tag de vídeo.
 </video>
 </div>
 
-## 1. Indique um amigo para o Skatehive usando sua conta
+## 1. Indique um Amigo para o Skatehive Usando Sua Conta
 
-![](https://i.ibb.co/ThBn2Kz/image.png)
+1. **Navegue até o ícone do robô** no topo do Skatehive ou [clique aqui](https://www.skatehive.app/invite).  
 
-## 2. Escolha seu nome de usuário 
-Lembre se que o nome de usuário não pode ser alterado após sua criação 
+<img src="https://i.ibb.co/JCCj9Sf/image.png" alt="Navegue até o Ícone do Robô" width="150" />
 
-![Digite o nome de usuário e e-mail](https://hackmd.io/_uploads/H1tZGNP1Jx.png)
+2. **Escolha o nome de usuário dele**. Certifique-se de que ele goste, pois não pode ser alterado facilmente. Digite o endereço de e-mail dele.  
+![Digite o Nome de Usuário e E-mail](https://hackmd.io/_uploads/H1tZGNP1Jx.png)
 
-## 3. Depois de clicar em **"Looks Good, Lets go for it!"**, uma transação na sua carteira será solicitada. Após a aprovação, a conta será criada e seu amigo receberá um e-mail.
+3. Depois de clicar em **"Parece Bom, Vá em Frente"**, será solicitada uma transação no Keychain. Após a aprovação, a conta será criada e seu amigo receberá um e-mail.
+
 ---
 
-## Receba um convite por e-mail
+## Receba um Convite por E-mail
 
-Seu amigo receberá um e-mail contendo suas **HIVE KEYS**.  
-![E-mail das chaves do Hive](https://ipfs.skatehive.app/ipfs/QmbTbULhRtAfyd19cTNYfrsjpsuRN2TV9sxZ5yzQQeR44D)
+Seu amigo receberá um e-mail contendo suas **CHAVES HIVE**.  
+![E-mail das Chaves Hive](https://ipfs.skatehive.app/ipfs/QmbTbULhRtAfyd19cTNYfrsjpsuRN2TV9sxZ5yzQQeR44D)
 
-### Importante: mantenha suas chaves seguras
+### Importante: Mantenha Suas Chaves Seguras
 - **Nunca perca suas chaves!** Elas não podem ser recuperadas se perdidas.
-- Skatehive.app não armazena cópias de suas chaves por motivos de segurança. É sua responsabilidade armazená-los com segurança.
+- Skatehive.app não armazena cópias de suas chaves por motivos de segurança. É sua responsabilidade armazená-las com segurança.
 
-### Fazendo login
-Use seu nome de usuário e senha para fazer login no Skatehive através de qualquer navegador. 
-#### Opções de carteiras Hive para celular
+### Fazendo Login
+Use seu nome de usuário e senha para fazer login no Skatehive através de qualquer navegador. No entanto, recomendamos o uso do **Hive Keychain** para a experiência mais segura.
 
-<div style={{ display: 'flex', justifiqueContent: 'center' }}>
-| iOS | Android |
+#### Opções de Hive Keychain para Celular
+
+<div style={{ display: 'flex', justifyContent: 'center' }}>
+
+
+| iOS  | Android |
 | -------- | -------- |
 | ![](https://hive-keychain.com/img/browsers/ios.svg) | ![](https://hive-keychain.com/img/browsers/android.svg) |  
 
 </div>
 
-#### Opções de carteiras Hive para desktop
+#### Opções de Hive Keychain para Desktop
 
 <div style={{
   display: 'flex', 
@@ -122,28 +126,29 @@ Use seu nome de usuário e senha para fazer login no Skatehive através de qualq
 
 ---
 
-## 2. Configurando a carteira Hive
+## 2. Configurando o Hive Keychain
 
-**Hive Keychain** armazena com segurança as informações da sua chave privada. Está disponível como extensão de navegador para desktop e como aplicativo móvel (que também serve como navegador da web). Use-o para fazer login nos sites compativeis com a Hive, incluindo o Skatehive.
+**Hive Keychain** armazena com segurança suas informações de chave privada. Está disponível como uma extensão de navegador para desktop e como um aplicativo móvel (que também serve como navegador da web). Use-o para fazer login nos frontends Hive, incluindo o Skatehive.
 
-### Para usuários móveis
-1. Crie um PIN para desbloquear a carteira.
+### Para Usuários Móveis
+1. Crie um PIN para desbloquear o keychain.
    ![Definir PIN](https://hackmd.io/_uploads/rk9Y1SDJJg.png)
 
 2. Após configurar o PIN, clique em **Usar Chaves/Senha** e digite sua **Senha Mestra**.  
-   ![Digite a senha mestra](https://hackmd.io/_uploads/HyBYyBwJJx.png)
+   ![Digite a Senha Mestra](https://hackmd.io/_uploads/HyBYyBwJJx.png)
 
 3. Faça login no Skatehive digitando seu **nome de usuário**.  
-   ![Faça login no Skatehive](https://hackmd.io/_uploads/ByGmlHDkJl.png)
+   ![Login no Skatehive](https://hackmd.io/_uploads/ByGmlHDkJl.png)
 
 Assim que o Hive Keychain aprovar a transação, você estará logado.
 
 ---
 
-## 3. Crie você mesmo uma conta Hive
+## 3. Crie uma Conta Hive Você Mesmo
 
-Você também pode criar contas Hive (carteiras) usando outros frontends Hive e depois usar essas contas para fazer login na Skatehive.
+Você também pode criar contas Hive (carteiras) usando outros frontends Hive e depois usar essas contas para fazer login no Skatehive.
 
 ### Passos:
 1. Certifique-se de ter o **Hive Keychain** instalado.
 2. Vá para [HiveOnboard](https://hiveonboard.com/create-account) e crie sua conta.
+


### PR DESCRIPTION
Translate the documentation files in the `docs` folder into Portuguese (pt-br), Spanish (es), and French (fr) and place them in the corresponding `i18n` folders.

* **Portuguese Translations:**
  - Modify `i18n/pt-br/docusaurus-plugin-content-docs/current/create-account.mdx` to translate the content of `docs/create-account.mdx` to Portuguese.
  - Modify `i18n/pt-br/docusaurus-plugin-content-docs/current/Level - 0/fork-skatehive.md` to translate the content of `docs/Level - 0/fork-skatehive.md` to Portuguese.

* **Spanish Translations:**
  - Add `i18n/es/docusaurus-plugin-content-docs/current/create-account.mdx` to translate the content of `docs/create-account.mdx` to Spanish.

* **French Translations:**
  - Add `i18n/fr/docusaurus-plugin-content-docs/current/create-account.mdx` to translate the content of `docs/create-account.mdx` to French.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sktbrd/skatehive-docs?shareId=XXXX-XXXX-XXXX-XXXX).